### PR TITLE
ci: health check retry + auto rollback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      - run: npm test
+        env:
+          NAVER_MAP_STYLE_ID: ${{ secrets.NAVER_MAP_STYLE_ID }}
+      - run: npm run lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,8 @@ jobs:
           script: |
             set -e
             cd ${{ secrets.DEPLOY_PATH }}
+
+            PREV_COMMIT=$(git rev-parse HEAD)
             git pull origin main
 
             # Update Nginx config
@@ -43,17 +45,28 @@ jobs:
             # Build new images
             docker compose build
 
+            rollback() {
+              echo "Deployment failed — rolling back to $PREV_COMMIT"
+              git checkout "$PREV_COMMIT"
+              docker compose build
+              docker compose up -d --no-deps api-1 api-2 poller
+              sleep 15
+              curl -sf http://localhost:3001/health/ready || echo "WARNING: rollback also failed"
+            }
+
             # Rolling update: one replica at a time
             docker compose up -d --no-deps api-1
-            sleep 15
-            curl -f http://localhost:3001/health/ready || exit 1
+            HEALTHY=false
+            for i in $(seq 1 6); do sleep 5; curl -sf http://localhost:3001/health/ready && HEALTHY=true && break; done
+            if [ "$HEALTHY" = false ]; then rollback; exit 1; fi
 
             docker compose up -d --no-deps api-2
-            sleep 15
-            curl -f http://localhost:3002/health/ready || exit 1
+            HEALTHY=false
+            for i in $(seq 1 6); do sleep 5; curl -sf http://localhost:3002/health/ready && HEALTHY=true && break; done
+            if [ "$HEALTHY" = false ]; then rollback; exit 1; fi
 
             # Update poller last (no downtime impact)
             docker compose up -d --no-deps poller
             sleep 10
-            docker compose ps poller --format '{{.State}}' | grep -q running || exit 1
+            docker compose ps poller --format '{{.State}}' | grep -q running || { rollback; exit 1; }
             docker compose logs poller --tail 5 | grep -q "MongoDB connected\|poller-only mode" || echo "WARNING: poller may not have initialized fully"

--- a/docs/cicd-and-branch-protection.md
+++ b/docs/cicd-and-branch-protection.md
@@ -1,33 +1,51 @@
 # CI/CD 및 브랜치 보호 전략
 
-## CI/CD 파이프라인
+## 워크플로우 구성
 
-### 트리거
+| 워크플로우 | 트리거 | 용도 |
+|---|---|---|
+| `ci.yml` | PR → main | test + lint 검증 |
+| `deploy.yml` | main push | test → OCI 자동 배포 + auto rollback |
+| `claude-code-review.yml` | PR 생성/업데이트 | 자동 코드 리뷰 |
+| `claude.yml` | `@claude` 멘션 | 대화형 응답 |
 
-`main` 브랜치에 push (PR 머지 포함) 시 자동 실행.
+---
 
-### 워크플로우 (`deploy.yml`)
+## CI (`ci.yml`) — PR 단계
+
+PR 생성 시 테스트/린트 통과 여부를 검증.
+
+```
+PR → main
+  └→ test job
+       ├→ npm ci
+       ├→ npm test
+       └→ npm run lint
+```
+
+## CD (`deploy.yml`) — 머지 후 배포
 
 ```
 main push
-  └→ GitHub Actions
-       ├→ [test] npm ci → npm test → npm run lint
-       └→ [deploy] (test 통과 후)
-            └→ SSH로 OCI 서버 접속 (appleboy/ssh-action)
-                 ├→ git pull origin main
-                 ├→ Nginx 설정 업데이트
-                 ├→ docker compose build
-                 ├→ Rolling update (api-1 → api-2 → poller)
-                 └→ 각 서비스 health check
+  ├→ test job (npm ci → test → lint)
+  └→ deploy job (test 통과 후, SSH → OCI)
+       ├→ PREV_COMMIT 저장
+       ├→ git pull origin main
+       ├→ Nginx 설정 업데이트
+       ├→ docker compose build
+       ├→ Rolling update (api-1 → api-2 → poller)
+       │    └→ 각 서비스 health check retry (5초 × 6회)
+       ├→ 성공 → 완료
+       └→ 실패 → rollback() → 전체 복원 (자동 rollback)
 ```
 
 ### Rolling Update 순서
 
-1. `api-1` 재시작 → 15초 대기 → health check (`/health/ready`)
-2. `api-2` 재시작 → 15초 대기 → health check (`/health/ready`)
-3. `poller` 재시작 → 10초 대기 → 상태 확인
+1. `api-1` 재시작 → health check retry → 통과 시 다음
+2. `api-2` 재시작 → health check retry → 통과 시 다음
+3. `poller` 재시작 → 상태 확인
 
-api-1, api-2가 순차 배포되므로 다운타임 없음.
+api-1, api-2가 순차 배포되므로 다운타임 없음. 어느 단계에서든 실패 시 전체 rollback.
 
 ### 배포 대상
 
@@ -71,24 +89,23 @@ api-1, api-2가 순차 배포되므로 다운타임 없음.
 | 규칙 | 설명 |
 |---|---|
 | PR 필수 | main 직접 push 차단. PR → CI 통과 → 머지 |
-| required_status_checks | `test` + `deploy` job 통과 필수 |
+| required_status_checks | `test` job 통과 필수 |
 | non_fast_forward | force push 방지 |
 | deletion | main 브랜치 삭제 방지 |
 
 ### Bypass
 
 - **Repository Admin**: 긴급 시 직접 push 가능 (bypass_mode: always)
-- **GitHub Actions bot**: bypass 불필요 (deploy workflow가 main에 push하지 않음)
 
-### 워크플로우
+### PR 머지 흐름
 
 ```
 feature branch 생성
   └→ 작업 & 커밋
        └→ PR 생성 (main ← feature)
-            └→ CI 자동 실행 (test → deploy)
-                 ├→ 통과 → 머지 가능
-                 └→ 실패 → 머지 차단
+            ├→ test check (npm test + lint)
+            ├→ Claude Code Review (자동 코드 리뷰)
+            └→ 둘 다 통과 → 머지 가능 → deploy 자동 실행
 ```
 
 ### 자동 Rollback

--- a/docs/cicd-and-branch-protection.md
+++ b/docs/cicd-and-branch-protection.md
@@ -1,0 +1,105 @@
+# CI/CD 및 브랜치 보호 전략
+
+## CI/CD 파이프라인
+
+### 트리거
+
+`main` 브랜치에 push (PR 머지 포함) 시 자동 실행.
+
+### 워크플로우 (`deploy.yml`)
+
+```
+main push
+  └→ GitHub Actions
+       ├→ [test] npm ci → npm test → npm run lint
+       └→ [deploy] (test 통과 후)
+            └→ SSH로 OCI 서버 접속 (appleboy/ssh-action)
+                 ├→ git pull origin main
+                 ├→ Nginx 설정 업데이트
+                 ├→ docker compose build
+                 ├→ Rolling update (api-1 → api-2 → poller)
+                 └→ 각 서비스 health check
+```
+
+### Rolling Update 순서
+
+1. `api-1` 재시작 → 15초 대기 → health check (`/health/ready`)
+2. `api-2` 재시작 → 15초 대기 → health check (`/health/ready`)
+3. `poller` 재시작 → 10초 대기 → 상태 확인
+
+api-1, api-2가 순차 배포되므로 다운타임 없음.
+
+### 배포 대상
+
+| 항목 | 값 |
+|---|---|
+| 서버 | OCI ARM VM (168.107.62.58) |
+| 유저 | ubuntu |
+| 경로 | `/home/ubuntu/skkumap-server-express` |
+| 도메인 | api.skkuverse.com (Cloudflare → Nginx → Docker) |
+| Docker 네트워크 | `skkuverse` (external) |
+
+### 서비스 구성
+
+| 서비스 | 포트 | 리소스 | 역할 |
+|---|---|---|---|
+| api-1 | 127.0.0.1:3001 | 384MB / 0.75 CPU | API (로드밸런싱) |
+| api-2 | 127.0.0.1:3002 | 384MB / 0.75 CPU | API (로드밸런싱) |
+| poller | — | 256MB / 0.5 CPU | 백그라운드 작업 |
+
+### AI 서비스 연동
+
+백엔드는 `skkuverse` Docker 네트워크를 통해 AI 서비스에 접근:
+- `http://ai:4000/v1/chat/completions` — 범용 채팅
+- `http://ai:4000/api/notices/summarize` — 공지 요약
+
+### GitHub Secrets
+
+| Secret | 용도 |
+|---|---|
+| `ORACLE_VM_HOST` | OCI 서버 IP |
+| `ORACLE_VM_USER` | SSH 유저 |
+| `SSH_PRIVATE_KEY` | SSH 개인키 |
+| `DEPLOY_PATH` | 배포 경로 |
+
+---
+
+## 브랜치 보호 (GitHub Rulesets)
+
+### 규칙
+
+| 규칙 | 설명 |
+|---|---|
+| PR 필수 | main 직접 push 차단. PR → CI 통과 → 머지 |
+| required_status_checks | `test` + `deploy` job 통과 필수 |
+| non_fast_forward | force push 방지 |
+| deletion | main 브랜치 삭제 방지 |
+
+### Bypass
+
+- **Repository Admin**: 긴급 시 직접 push 가능 (bypass_mode: always)
+- **GitHub Actions bot**: bypass 불필요 (deploy workflow가 main에 push하지 않음)
+
+### 워크플로우
+
+```
+feature branch 생성
+  └→ 작업 & 커밋
+       └→ PR 생성 (main ← feature)
+            └→ CI 자동 실행 (test → deploy)
+                 ├→ 통과 → 머지 가능
+                 └→ 실패 → 머지 차단
+```
+
+### 자동 Rollback
+
+배포 스크립트에 자동 rollback 내장. rolling update 중 health check 실패 시:
+
+1. 배포 전 커밋 해시 저장 (`PREV_COMMIT`)
+2. api-1 또는 api-2 health check 30초간 retry (5초 × 6회)
+3. 실패 시 `git checkout $PREV_COMMIT` → 이전 이미지로 api-1, api-2, poller 전체 복원
+4. CI는 실패로 표시 (GitHub에서 확인 가능)
+
+### 긴급 hotfix
+
+Admin은 bypass 권한이 있으므로 main에 직접 push 가능. 단, 의도적으로만 사용할 것.


### PR DESCRIPTION
## Summary
- api-1, api-2 health check를 단발 curl에서 5초×6회 retry loop으로 변경
- rollback() 함수 추가: health check 실패 시 이전 커밋으로 전체 복원 (api-1, api-2, poller)
- CI/CD 및 브랜치 보호 전략 문서 추가

## Test plan
- [ ] PR 머지 후 GitHub Actions test + deploy job 통과 확인
- [ ] OCI에서 rolling update 정상 완료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)