### PR TITLE
ci: pre-deploy config validation (fail-fast on missing env vars)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,22 @@ jobs:
             # Build new images
             docker compose build
 
+            # --- Pre-deploy config validation ---
+            # Dry-load lib/config.js inside the freshly-built image with the
+            # VM's .env (inherited via env_file in docker-compose.yml). If
+            # any required env var is missing, lib/config calls process.exit(1),
+            # this command returns non-zero, and we abort the deploy BEFORE
+            # touching running containers. Clean git revert — no crash loop,
+            # no rolling update, no rollback function needed.
+            echo "=== Pre-deploy config validation ==="
+            if ! docker compose run --rm --no-deps -T api-1 \
+                 node -e "require('./lib/config'); console.log('config ok')"; then
+              echo "ERROR: production config validation failed — aborting deploy."
+              echo "       See the FATAL error above for the missing env var(s)."
+              git checkout "$PREV_COMMIT"
+              exit 1
+            fi
+
             rollback() {
               echo "Deployment failed — rolling back to $PREV_COMMIT"
               git checkout "$PREV_COMMIT"


### PR DESCRIPTION
## Context

Second half of the post-incident hardening series. [#44](https://github.com/spencer0124/skkuverse-server/pull/44) removed silent fallbacks in `lib/config.js` and made missing required env vars crash loudly with an actionable error message. This PR adds the CI/CD safety net that catches those crashes **before** the destructive rolling update — so missing env vars fail fast in ~2s instead of triggering a 60s crash-loop + rollback cycle.

Refs [#43](https://github.com/spencer0124/skkuverse-server/pull/43), [#44](https://github.com/spencer0124/skkuverse-server/pull/44), incident run [24230429834](https://github.com/spencer0124/skkuverse-server/actions/runs/24230429834).

## What changed

A single new step in `.github/workflows/deploy.yml`, inserted between `docker compose build` and the `rollback()` function definition:

```bash
echo "=== Pre-deploy config validation ==="
if ! docker compose run --rm --no-deps -T api-1 \
     node -e "require('./lib/config'); console.log('config ok')"; then
  echo "ERROR: production config validation failed — aborting deploy."
  echo "       See the FATAL error above for the missing env var(s)."
  git checkout "$PREV_COMMIT"
  exit 1
fi
```

Nothing else in the workflow changes. The existing `rollback()` function and rolling-update health checks stay exactly as they are — this PR just adds an earlier, cleaner abort path.

## How the dry-load works

- `docker compose run --rm --no-deps -T api-1`: spin up a **throwaway** container from the just-built image
  - `--rm` auto-removes after exit
  - `--no-deps` prevents starting the poller dependency
  - `-T` disables TTY (required for non-interactive CI)
- `node -e "require('./lib/config'); console.log('config ok')"`: override the Dockerfile `CMD`, just load the config module — **no server starts**, no ports are bound
- The container inherits the VM's `.env` via `env_file: - .env` in `docker-compose.yml`, and `NODE_ENV=production` via the compose `environment:` section
- If any required env var is missing, `lib/config.js` hits `process.exit(1)` (the hard crash path added in #44), the container exits non-zero, `if !` catches it, and the deploy aborts with a clean `git checkout $PREV_COMMIT`

## Before vs after

**Before** (the PR #43 incident pattern):
```
build → rolling update api-1 → new container crash-loops → 30s health
check timeout → rollback() runs → git checkout PREV → rebuild → restart
all three containers → ~60s downtime risk → exit 1
```

**After**:
```
build → dry-load config in throwaway container → non-zero exit → git
checkout PREV → exit 1 → running containers untouched → 0 downtime
```

The `rollback()` function is **still needed** — it still protects against failures *during* rolling update (transient DB issues, real application bugs). This PR just adds a faster path for the specific "missing env var" failure class.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` — YAML valid
- [ ] First deploy run after merge exercises the new step — expected log:
  ```
  === Pre-deploy config validation ===
  config ok
  ```
- [ ] Rolling update proceeds as before (VM `.env` has all required vars, verified during #44 work)

## Risk

The workflow change is the only risk — if the `docker compose run` invocation is wrong (bad flags, image issue), **every deploy blocks**. Mitigation:

1. If this PR's first deploy fails because of the new step itself (not because of missing env vars), immediately revert via a follow-up PR reverting this file
2. The rollback mechanism from PR #42 still protects against actual rolling-update failures, so production is safe either way
3. Monitored first deploy — watch `gh run watch` output for the new log line

## Related

- Hardening series: PR #44 (config strict) + this PR (workflow validation)
- Auto-rollback mechanism from PR #42 is preserved intact
- Architecture doc: `docs/notices-api-architecture.md` (incident analysis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)