### PR TITLE
fix(notices): don't leak Array.map index into toListItem now param

### DIFF
--- a/__tests__/notices-routes.test.js
+++ b/__tests__/notices-routes.test.js
@@ -134,6 +134,53 @@ describe("GET /notices/dept/:deptId", () => {
     expect(res.body.data.nextCursor).toBeNull();
   });
 
+  it("does not crash when .map leaks array index into toListItem's now param (regression: action_required best-pick)", async () => {
+    // Two action_required docs. The first has no meaningful periods so
+    // selectEffectivePeriod early-returns null (this is the only case
+    // that used to hide the bug). The second has a real upcoming
+    // deadline, so selectEffectivePeriod reaches `now.getTime()`. If
+    // `items.map(toListItem)` is called bare, Array.prototype.map passes
+    // the index (0, 1, …) as the 2nd argument, which shadows `now`
+    // with a number and crashes with TypeError at `now.getTime()`.
+    mockFindByDept.mockResolvedValue({
+      items: [
+        rawDoc({
+          _id: new ObjectId("66a1b2c3d4e5f6a7b8c9d0e1"),
+          articleNo: 999001,
+          summaryAt: new Date("2026-04-11T00:00:00.000Z"),
+          summaryType: "action_required",
+          summaryPeriods: [],
+        }),
+        rawDoc({
+          _id: new ObjectId("66a1b2c3d4e5f6a7b8c9d0e2"),
+          articleNo: 999002,
+          summaryAt: new Date("2026-04-11T00:00:00.000Z"),
+          summaryType: "action_required",
+          summaryPeriods: [
+            {
+              label: "1차 신청",
+              startDate: "2026-04-05",
+              startTime: null,
+              endDate: "2026-04-20",
+              endTime: "17:00",
+            },
+          ],
+        }),
+      ],
+      nextCursor: null,
+      hasMore: false,
+    });
+    const res = await request(app).get("/notices/dept/skku-main");
+    expect(res.status).toBe(200);
+    expect(res.body.data.notices).toHaveLength(2);
+    expect(res.body.data.notices[1].summary).toEqual({
+      oneLiner: null,
+      type: "action_required",
+      startAt: { date: "2026-04-05", time: null },
+      endAt: { date: "2026-04-20", time: "17:00", label: "1차 신청" },
+    });
+  });
+
   it("clamps limit to 1..50 range", async () => {
     mockFindByDept.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
     await request(app).get("/notices/dept/skku-main?limit=999");

--- a/features/notices/notices.routes.js
+++ b/features/notices/notices.routes.js
@@ -87,7 +87,11 @@ router.get(
       limit,
       type,
     });
-    const notices = items.map(toListItem);
+    // Explicit arrow wrapper: `Array.prototype.map` passes (element, index,
+    // array) — passing `toListItem` bare would leak the numeric index into
+    // `toListItem`'s second `now` param and crash action_required best-pick
+    // at `now.getTime()`. See regression test in notices-routes.test.js.
+    const notices = items.map((doc) => toListItem(doc));
     res.success(
       { notices, nextCursor, hasMore },
       { count: notices.length }


### PR DESCRIPTION
## Summary
- Production `GET /notices/dept/skku-main` returned 500 whenever the list contained an action_required notice with a real deadline.
- Root cause: `bb0d434` added a `now = new Date()` second param to `toListItem` for deterministic best-pick tests, but the route was still calling `items.map(toListItem)` — `Array.prototype.map` passes `(el, index, array)`, so the numeric index was shadowing `now`. Inside `selectEffectivePeriod`, `now.getTime()` threw `TypeError`.
- The existing \"maps docs through toListItem\" test only mocked 1 doc with no periods, so `selectEffectivePeriod` early-returned before reaching `now.getTime()` — hiding the bug exactly like the first action_required notice on prod (which happened to be deadline-less).

## Fix
- Wrap the `.map` callback: `items.map((doc) => toListItem(doc))` so `now` falls back to its default `new Date()`.
- Add a regression test that mocks 2 action_required docs: one deadline-less (hits the early-return path) and one with a real `summaryPeriods` entry (forces the `now.getTime()` path). The test fails against unpatched code with status 500, passes after the fix.

## Test plan
- [x] `npm test` — 425/425 pass (424 prior + 1 new regression)
- [x] Verified test actually fails when the fix is reverted (confirmed TypeError → 500)
- [ ] After deploy: `curl -sS -w "\nhttp=%{http_code}\n" "https://api.skkuverse.com/notices/dept/skku-main?limit=20"` → expect 200
- [ ] After deploy: `curl -sS -w "\nhttp=%{http_code}\n" "https://api.skkuverse.com/notices/dept/skku-main?type=action_required&limit=20"` → expect 200
- [ ] Open app on simulator → 공지 탭 → 학부통합(학사) → list renders with D-day badges on real deadlines

🤖 Generated with [Claude Code](https://claude.com/claude-code)