### PR TITLE
feat: attachment proxy endpoint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,8 @@ module.exports = [
         process: "readonly",
         console: "readonly",
         Buffer: "readonly",
+        URL: "readonly",
+        URLSearchParams: "readonly",
         setTimeout: "readonly",
         setInterval: "readonly",
         clearTimeout: "readonly",

--- a/features/notices/notices.routes.js
+++ b/features/notices/notices.routes.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const router = express.Router();
+const axios = require("axios");
 const asyncHandler = require("../../lib/asyncHandler");
 const {
   findNoticesByDept,
@@ -96,6 +97,61 @@ router.get(
       { notices, nextCursor, hasMore },
       { count: notices.length }
     );
+  })
+);
+
+// GET /notices/proxy/attachment?url=...&referer=...&mode=inline|download
+// Proxies attachment downloads with a Referer header to bypass hotlink
+// protection on some SKKU department servers (e.g. cal.skku.edu).
+// Only *.skku.edu hosts are allowed to prevent open-proxy abuse.
+router.get(
+  "/proxy/attachment",
+  asyncHandler(async (req, res) => {
+    const { url, referer, mode } = req.query;
+    if (!url || !referer) {
+      return res.error(400, "INVALID_PARAMS", "url and referer required");
+    }
+
+    let targetHost;
+    try {
+      targetHost = new URL(url).hostname;
+    } catch {
+      return res.error(400, "INVALID_PARAMS", "malformed url");
+    }
+
+    if (!targetHost.endsWith("skku.edu")) {
+      return res.error(403, "FORBIDDEN", "only skku.edu hosts allowed");
+    }
+
+    const upstream = await axios.get(url, {
+      headers: {
+        Referer: referer,
+        "User-Agent": "Mozilla/5.0",
+      },
+      responseType: "stream",
+      timeout: 15000,
+    });
+
+    const ct = upstream.headers["content-type"];
+    if (ct) res.setHeader("Content-Type", ct);
+
+    if (mode === "download") {
+      // Extract filename from upstream Content-Disposition or URL
+      const upstreamCd = upstream.headers["content-disposition"];
+      const filenameMatch = upstreamCd && upstreamCd.match(/filename\*?=(?:UTF-8''|"?)([^";]+)/i);
+      const filename = filenameMatch
+        ? decodeURIComponent(filenameMatch[1].replace(/^"/, ""))
+        : new URL(url).pathname.split("/").pop() || "attachment";
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="${encodeURIComponent(filename)}"`
+      );
+    } else {
+      // mode=inline (default): force inline display
+      res.setHeader("Content-Disposition", "inline");
+    }
+
+    upstream.data.pipe(res);
   })
 );
 


### PR DESCRIPTION
## Summary
- Add `GET /notices/proxy/attachment` endpoint that proxies attachment downloads with Referer header for SKKU department servers that enforce hotlink protection (e.g. cal.skku.edu)
- Supports `mode=inline` (preview) and `mode=download` (force download with filename)
- Whitelisted to `*.skku.edu` only to prevent open-proxy abuse
- Add `URL`/`URLSearchParams` to ESLint globals

## Test plan
- [x] `npm test` — 425 tests pass
- [x] `npm run lint` — clean
- [ ] curl test with cal.skku.edu attachment URL after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)