### PR TITLE
fix: force download for PDF attachments

### DIFF
--- a/features/notices/notices.routes.js
+++ b/features/notices/notices.routes.js
@@ -172,14 +172,15 @@ router.get(
     const filename = name || new URL(url).pathname.split("/").pop() || "attachment";
     const upstreamCt = upstream.headers["content-type"];
 
-    res.setHeader("Content-Type", resolveContentType(upstreamCt, filename));
-
     if (mode === "download") {
+      // Force octet-stream so Safari/Chrome downloads instead of previewing
+      res.setHeader("Content-Type", "application/octet-stream");
       res.setHeader(
         "Content-Disposition",
         `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`
       );
     } else {
+      res.setHeader("Content-Type", resolveContentType(upstreamCt, filename));
       res.setHeader("Content-Disposition", "inline");
     }
 


### PR DESCRIPTION
## Summary
- Override Content-Type to `application/octet-stream` in download mode
- Prevents SFSafariViewController from auto-previewing PDFs when user taps download

## Test plan
- [x] `npm test` — 425 pass
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)