### PR TITLE
feat(notices): add library department IDs

### DIFF
--- a/features/notices/departments.json
+++ b/features/notices/departments.json
@@ -1150,5 +1150,29 @@
     "category": null,
     "hasCategory": false,
     "hasAuthor": true
+  },
+  {
+    "id": "lib-seoul",
+    "name": "도서관(인사캠/중앙학술정보관)",
+    "campus": null,
+    "category": null,
+    "hasCategory": true,
+    "hasAuthor": false
+  },
+  {
+    "id": "lib-suwon",
+    "name": "도서관(자과캠/삼성학술정보관)",
+    "campus": null,
+    "category": null,
+    "hasCategory": true,
+    "hasAuthor": false
+  },
+  {
+    "id": "lib-all",
+    "name": "도서관(전체/양캠퍼스공통)",
+    "campus": null,
+    "category": null,
+    "hasCategory": true,
+    "hasAuthor": false
   }
 ]


### PR DESCRIPTION
## Summary
- lib-seoul, lib-suwon, lib-all 추가 (departments.json 144→147)
- 크롤러의 pyxis-api 전략으로 수집된 도서관 공지를 API에서 서빙

## Test plan
- [ ] `GET /notices/dept/lib-seoul` 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)