### PR TITLE
test: update department count for library sources (144→147)

### DIFF
--- a/__tests__/notices-departments.test.js
+++ b/__tests__/notices-departments.test.js
@@ -1,8 +1,8 @@
 const departments = require("../features/notices/departments");
 
 describe("departments loader", () => {
-  it("loads 144 entries", () => {
-    expect(departments.list).toHaveLength(144);
+  it("loads 147 entries", () => {
+    expect(departments.list).toHaveLength(147);
   });
 
   it("every entry has the required shape", () => {

--- a/__tests__/notices-routes.test.js
+++ b/__tests__/notices-routes.test.js
@@ -60,12 +60,12 @@ beforeEach(() => {
 });
 
 describe("GET /notices/departments", () => {
-  it("returns 144 departments with version and meta envelope", async () => {
+  it("returns 147 departments with version and meta envelope", async () => {
     const res = await request(app).get("/notices/departments");
     expect(res.status).toBe(200);
     expect(res.body.meta).toHaveProperty("lang");
-    expect(res.body.meta.count).toBe(144);
-    expect(res.body.data.departments).toHaveLength(144);
+    expect(res.body.meta.count).toBe(147);
+    expect(res.body.data.departments).toHaveLength(147);
     expect(res.body.data.version).toMatch(/^[0-9a-f]{64}$/);
   });
 


### PR DESCRIPTION
## Summary
- 테스트 하드코딩 144→147 수정 (lib-seoul, lib-suwon, lib-all 추가분)

🤖 Generated with [Claude Code](https://claude.com/claude-code)