### PR TITLE
feat(notices): search via q parameter on /notices(?source/:sourceId)?

### DIFF
--- a/__tests__/notices-data.test.js
+++ b/__tests__/notices-data.test.js
@@ -16,15 +16,17 @@ const {
   getNoticesCollection,
   ensureNoticeIndexes,
   findNoticesBySource,
+  findNoticesBySources,
   findNoticeByArticleNo,
   LIST_PROJECTION,
   DETAIL_PROJECTION,
 } = require("../features/notices/notices.data");
 
-// Chain helper to stub find().sort().limit().toArray()
+// Chain helper to stub find().sort().hint().limit().toArray()
 function stubFindChain(docs) {
   const chain = {
     sort: jest.fn().mockReturnThis(),
+    hint: jest.fn().mockReturnThis(),
     limit: jest.fn().mockReturnThis(),
     toArray: jest.fn().mockResolvedValue(docs),
   };
@@ -191,5 +193,200 @@ describe("findNoticeByArticleNo", () => {
 
   it("LIST_PROJECTION excludes cleanMarkdown (detail-only field)", () => {
     expect(LIST_PROJECTION).not.toHaveProperty("cleanMarkdown");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Notice search (q parameter) — data-layer integration tests.
+//
+// These exercise the lower-level concerns that route-level tests can't
+// reach with mocks: the actual filter shape, regex escape application,
+// $and composition order, and the .hint() force on every query.
+//
+// Plan-mandated cases (cross-reference with notices-routes.test.js):
+//   (a) regex metachar in q — verified here via filter shape (escaped)
+//   (b) q="" → missing — verified at routes layer
+//   (c) q + cursor round-trip — verified at routes layer
+//   (d) cursor + regex $and composition — verified here
+//   (e) summaryOneLiner null fallback — verified here as query-shape
+//       (both branches present); MongoDB native $or treats missing /
+//       null fields as false, so we rely on documented behavior
+//   (f) type filter + q both apply — verified here AND at routes layer
+// ──────────────────────────────────────────────────────────────────────
+
+describe("findNoticesBySource — search query (q)", () => {
+  it("does NOT add a search $or when q is missing", async () => {
+    stubFindChain([]);
+    await findNoticesBySource("skku-main", { limit: 20 });
+    const [filter] = mockCollection.find.mock.calls[0];
+    // $and has only the serviceStartDate clause (no search $or yet)
+    const searchOr = (filter.$and || []).find(
+      (clause) =>
+        Array.isArray(clause.$or) &&
+        clause.$or.some((branch) => branch.title)
+    );
+    expect(searchOr).toBeUndefined();
+  });
+
+  it("adds search $or with BOTH title + summaryOneLiner branches when q is present", async () => {
+    stubFindChain([]);
+    await findNoticesBySource("skku-main", { limit: 20, q: "공지" });
+    const [filter] = mockCollection.find.mock.calls[0];
+    const searchOr = filter.$and.find(
+      (clause) =>
+        Array.isArray(clause.$or) &&
+        clause.$or.some((branch) => branch.title)
+    );
+    expect(searchOr).toBeDefined();
+    // Both branches present — MongoDB native $or handles null/missing
+    // summaryOneLiner as the second branch evaluating false, so a doc
+    // with a NULL summaryOneLiner falls back to title-only matching.
+    // Documents this contract via shape rather than by simulating the
+    // fallback (which is MongoDB's responsibility).
+    expect(searchOr.$or).toHaveLength(2);
+    const titleBranch = searchOr.$or.find((b) => b.title);
+    const summaryBranch = searchOr.$or.find((b) => b.summaryOneLiner);
+    expect(titleBranch).toBeDefined();
+    expect(summaryBranch).toBeDefined();
+    expect(titleBranch.title.$options).toBe("i");
+    expect(summaryBranch.summaryOneLiner.$options).toBe("i");
+  });
+
+  it("escapes regex metacharacters in q before composing the $regex pattern", async () => {
+    stubFindChain([]);
+    await findNoticesBySource("skku-main", { limit: 20, q: ".*" });
+    const [filter] = mockCollection.find.mock.calls[0];
+    const searchOr = filter.$and.find(
+      (clause) => Array.isArray(clause.$or) && clause.$or.some((b) => b.title)
+    );
+    const titleBranch = searchOr.$or.find((b) => b.title);
+    // ".*"  →  "\\.\\*"   (each metachar prefixed with backslash)
+    expect(titleBranch.title.$regex).toBe("\\.\\*");
+  });
+
+  it("composes search $or alongside cursor $or inside a single $and (no top-level conflict)", async () => {
+    stubFindChain([]);
+    const cursor = {
+      d: "2026-04-05",
+      c: "2026-04-05T00:00:00.000Z",
+      i: "66a1b2c3d4e5f6a7b8c9d0e1",
+    };
+    await findNoticesBySource("skku-main", {
+      limit: 20,
+      q: "공지",
+      cursor,
+    });
+    const [filter] = mockCollection.find.mock.calls[0];
+    // Top-level $or must NOT exist (would conflict with cursor's keyset $or)
+    expect(filter.$or).toBeUndefined();
+    // Both clauses live inside $and — date + cursor $or + search $or = 3 entries
+    expect(filter.$and).toHaveLength(3);
+    const dateClause = filter.$and.find((c) => c.date);
+    const cursorClause = filter.$and.find(
+      (c) => Array.isArray(c.$or) && c.$or.some((b) => b._id || b.crawledAt)
+    );
+    const searchClause = filter.$and.find(
+      (c) => Array.isArray(c.$or) && c.$or.some((b) => b.title)
+    );
+    expect(dateClause).toBeDefined();
+    expect(cursorClause).toBeDefined();
+    expect(searchClause).toBeDefined();
+  });
+
+  it("composes type filter alongside search $or", async () => {
+    stubFindChain([]);
+    await findNoticesBySource("skku-main", {
+      limit: 20,
+      q: "장학금",
+      type: "action_required",
+    });
+    const [filter] = mockCollection.find.mock.calls[0];
+    // type → top-level summaryType equality (existing behavior, unchanged)
+    expect(filter.summaryType).toBe("action_required");
+    // search → $or inside $and
+    const searchClause = filter.$and.find(
+      (c) => Array.isArray(c.$or) && c.$or.some((b) => b.title)
+    );
+    expect(searchClause).toBeDefined();
+  });
+
+  it("trims and escapes empty-result-prone queries safely", async () => {
+    // Mirror routes-layer trimming: routes pass already-trimmed q, but
+    // data layer must not crash on weird-but-valid input.
+    stubFindChain([]);
+    await findNoticesBySource("skku-main", { limit: 20, q: "[]" });
+    const [filter] = mockCollection.find.mock.calls[0];
+    const searchOr = filter.$and.find(
+      (clause) => Array.isArray(clause.$or) && clause.$or.some((b) => b.title)
+    );
+    const titleBranch = searchOr.$or.find((b) => b.title);
+    expect(titleBranch.title.$regex).toBe("\\[\\]");
+  });
+});
+
+describe("findNoticesBySources — multi-source search query (q)", () => {
+  it("uses sourceId $in AND adds search $or when q is present", async () => {
+    stubFindChain([]);
+    await findNoticesBySources(["skku-main", "cse-undergrad"], {
+      limit: 20,
+      q: "공지",
+    });
+    const [filter] = mockCollection.find.mock.calls[0];
+    expect(filter.sourceId).toEqual({ $in: ["skku-main", "cse-undergrad"] });
+    const searchOr = filter.$and.find(
+      (clause) => Array.isArray(clause.$or) && clause.$or.some((b) => b.title)
+    );
+    expect(searchOr).toBeDefined();
+    expect(searchOr.$or).toHaveLength(2);
+  });
+
+  it("does NOT add search $or when q is missing on multi-source endpoint", async () => {
+    stubFindChain([]);
+    await findNoticesBySources(["skku-main", "cse-undergrad"], { limit: 20 });
+    const [filter] = mockCollection.find.mock.calls[0];
+    const searchOr = (filter.$and || []).find(
+      (clause) =>
+        Array.isArray(clause.$or) &&
+        clause.$or.some((branch) => branch.title)
+    );
+    expect(searchOr).toBeUndefined();
+  });
+});
+
+describe("query plan hint (4-key compound index)", () => {
+  it("calls .hint({sourceId:1, date:-1, crawledAt:-1, _id:-1}) on every single-source query", async () => {
+    const chain = stubFindChain([]);
+    await findNoticesBySource("skku-main", { limit: 20 });
+    expect(chain.hint).toHaveBeenCalledWith({
+      sourceId: 1,
+      date: -1,
+      crawledAt: -1,
+      _id: -1,
+    });
+  });
+
+  it("calls .hint() with the 4-key compound on multi-source queries", async () => {
+    const chain = stubFindChain([]);
+    await findNoticesBySources(["skku-main", "cse-undergrad"], { limit: 20 });
+    // The hint protects $in worst-case from picking the orphan
+    // sourceId_1_date_-1 (2-key) index, which causes in-memory SORT
+    // (verified prod measurement Phase 0a, 2026-04-26).
+    expect(chain.hint).toHaveBeenCalledWith({
+      sourceId: 1,
+      date: -1,
+      crawledAt: -1,
+      _id: -1,
+    });
+  });
+
+  it("hint is called with or without q (search regex doesn't change the index)", async () => {
+    const chainNoQ = stubFindChain([]);
+    await findNoticesBySource("skku-main", { limit: 20 });
+    expect(chainNoQ.hint).toHaveBeenCalledTimes(1);
+
+    mockCollection.find.mockClear();
+    const chainWithQ = stubFindChain([]);
+    await findNoticesBySource("skku-main", { limit: 20, q: "공지" });
+    expect(chainWithQ.hint).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/notices-routes.test.js
+++ b/__tests__/notices-routes.test.js
@@ -23,10 +23,12 @@ jest.mock("../features/ad/ad.data", () => ({
 
 // Mock the notices.data layer
 const mockFindBySource = jest.fn();
+const mockFindBySources = jest.fn();
 const mockFindByArticleNo = jest.fn();
 jest.mock("../features/notices/notices.data", () => ({
   ensureNoticeIndexes: jest.fn().mockResolvedValue(),
   findNoticesBySource: (...args) => mockFindBySource(...args),
+  findNoticesBySources: (...args) => mockFindBySources(...args),
   findNoticeByArticleNo: (...args) => mockFindByArticleNo(...args),
 }));
 
@@ -341,5 +343,169 @@ describe("route ordering", () => {
     const res = await request(app).get("/notices/tabs");
     expect(res.status).toBe(200);
     expect(res.body.data.tabs).toBeDefined();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Notice search (q parameter) — routes-level integration tests.
+// The data layer is mocked, so these tests verify the route's parsing,
+// validation, and pass-through behavior. Query-shape composition (regex
+// escape, $or branches, .hint(), $and order) lives in notices-data.test.js
+// where the mocked find chain lets us assert the actual filter object.
+//
+// Plan-mandated cases (all six are exercised here at the route layer;
+// the data-layer mirrors live in notices-data.test.js):
+//   (a) regex metachars pass through to data layer raw — escape is the
+//       data layer's responsibility, so the route hands off the user
+//       string unchanged.
+//   (b) q="" treated as missing — no q reaches the data layer.
+//   (c) q + cursor round-trip — both forwarded together.
+//   (d) cursor + regex $and composition — verified at data layer; route
+//       just confirms cursor and q both reach the data layer call.
+//   (e) summaryOneLiner null fallback — verified at data layer (query
+//       has both branches; MongoDB native $or treats missing fields as
+//       false). Route layer cannot exercise the actual fallback without
+//       a real DB; we confirm pass-through here.
+//   (f) type filter + q both apply — both reach the data layer.
+// ──────────────────────────────────────────────────────────────────────
+
+describe("GET /notices/source/:sourceId — search query", () => {
+  beforeEach(() => {
+    mockFindBySource.mockResolvedValue({
+      items: [],
+      nextCursor: null,
+      hasMore: false,
+    });
+  });
+
+  // Case (a)
+  it("forwards regex-metachar q raw to the data layer (escape is data-layer's job)", async () => {
+    await request(app).get("/notices/source/skku-main?q=.%2A%2B%3F"); // .*+?
+    expect(mockFindBySource).toHaveBeenCalledWith(
+      "skku-main",
+      expect.objectContaining({ q: ".*+?" })
+    );
+  });
+
+  // Case (b)
+  it("treats q='' as missing — no q in data layer call", async () => {
+    await request(app).get("/notices/source/skku-main?q=");
+    const callArgs = mockFindBySource.mock.calls[0][1];
+    expect(callArgs.q).toBeUndefined();
+  });
+
+  it("treats whitespace-only q as missing", async () => {
+    await request(app).get("/notices/source/skku-main?q=%20%20%20");
+    const callArgs = mockFindBySource.mock.calls[0][1];
+    expect(callArgs.q).toBeUndefined();
+  });
+
+  it("missing q (param absent) is missing — no q in data layer call", async () => {
+    await request(app).get("/notices/source/skku-main");
+    const callArgs = mockFindBySource.mock.calls[0][1];
+    expect(callArgs.q).toBeUndefined();
+  });
+
+  // Case (c) + (d) bridge
+  it("round-trips q + cursor together to the data layer", async () => {
+    const cursor = encodeCursor({
+      d: "2026-04-01",
+      c: "2026-04-01T00:00:00.000Z",
+      i: "66a1b2c3d4e5f6a7b8c9d0e1",
+    });
+    await request(app).get(
+      `/notices/source/skku-main?q=%EA%B3%B5%EC%A7%80&cursor=${cursor}`
+    );
+    const callArgs = mockFindBySource.mock.calls[0][1];
+    expect(callArgs.q).toBe("공지");
+    expect(callArgs.cursor).toEqual({
+      d: "2026-04-01",
+      c: "2026-04-01T00:00:00.000Z",
+      i: "66a1b2c3d4e5f6a7b8c9d0e1",
+    });
+  });
+
+  // Case (f)
+  it("forwards q + type filter together", async () => {
+    await request(app).get(
+      "/notices/source/skku-main?q=%EC%9E%A5%ED%95%99%EA%B8%88&type=action_required"
+    );
+    expect(mockFindBySource).toHaveBeenCalledWith(
+      "skku-main",
+      expect.objectContaining({
+        q: "장학금",
+        type: "action_required",
+      })
+    );
+  });
+
+  it("trims surrounding whitespace before forwarding", async () => {
+    await request(app).get("/notices/source/skku-main?q=%20%20hello%20%20");
+    expect(mockFindBySource).toHaveBeenCalledWith(
+      "skku-main",
+      expect.objectContaining({ q: "hello" })
+    );
+  });
+
+  it("silently drops q exceeding 100 codepoints", async () => {
+    // 101 'x' chars — too long. validateQ returns null, route omits q.
+    const tooLong = "x".repeat(101);
+    await request(app).get(`/notices/source/skku-main?q=${tooLong}`);
+    const callArgs = mockFindBySource.mock.calls[0][1];
+    expect(callArgs.q).toBeUndefined();
+  });
+
+  it("silently drops q containing control characters", async () => {
+    // %00 NUL — must not reach the data layer.
+    await request(app).get("/notices/source/skku-main?q=abc%00def");
+    const callArgs = mockFindBySource.mock.calls[0][1];
+    expect(callArgs.q).toBeUndefined();
+  });
+});
+
+describe("GET /notices — multi-source search query", () => {
+  beforeEach(() => {
+    mockFindBySources.mockResolvedValue({
+      items: [],
+      nextCursor: null,
+      hasMore: false,
+    });
+  });
+
+  it("forwards q to findNoticesBySources alongside sourceIds", async () => {
+    await request(app).get(
+      "/notices?sourceIds=skku-main,cse-undergrad&q=%EA%B3%B5%EC%A7%80"
+    );
+    expect(mockFindBySources).toHaveBeenCalledWith(
+      ["skku-main", "cse-undergrad"],
+      expect.objectContaining({ q: "공지" })
+    );
+  });
+
+  it("treats q='' as missing on multi-source endpoint", async () => {
+    await request(app).get(
+      "/notices?sourceIds=skku-main,cse-undergrad&q="
+    );
+    const callArgs = mockFindBySources.mock.calls[0][1];
+    expect(callArgs.q).toBeUndefined();
+  });
+
+  it("forwards q + cursor + type together on multi-source endpoint", async () => {
+    const cursor = encodeCursor({
+      d: "2026-04-01",
+      c: "2026-04-01T00:00:00.000Z",
+      i: "66a1b2c3d4e5f6a7b8c9d0e1",
+    });
+    await request(app).get(
+      `/notices?sourceIds=skku-main,cse-undergrad&q=%EC%9E%A5%ED%95%99%EA%B8%88&type=action_required&cursor=${cursor}`
+    );
+    const callArgs = mockFindBySources.mock.calls[0][1];
+    expect(callArgs.q).toBe("장학금");
+    expect(callArgs.type).toBe("action_required");
+    expect(callArgs.cursor).toEqual({
+      d: "2026-04-01",
+      c: "2026-04-01T00:00:00.000Z",
+      i: "66a1b2c3d4e5f6a7b8c9d0e1",
+    });
   });
 });

--- a/__tests__/notices-search.test.js
+++ b/__tests__/notices-search.test.js
@@ -1,0 +1,171 @@
+// Unit tests for notices.search.js helpers — pure functions, no DB.
+//
+// escapeRegex(s)  : escape every regex metacharacter so user input becomes
+//                   a literal pattern when fed to RegExp / $regex.
+// validateQ(raw)  : normalize a request query value into a trimmed string
+//                   ready for Mongo, or null when the input should be
+//                   ignored (missing, empty, malformed, too long).
+//
+// Contract: validateQ NEVER throws. Bad inputs degrade silently to null
+// so the route layer can simply `if (q)` to decide whether to compose
+// the search clause. The client owns user-facing length feedback via
+// debounce + min-length gating; the server is purely defensive.
+
+const { escapeRegex, validateQ } = require("../features/notices/notices.search");
+
+describe("escapeRegex", () => {
+  it("returns empty string unchanged", () => {
+    expect(escapeRegex("")).toBe("");
+  });
+
+  it("returns plain alphanumeric/Korean unchanged", () => {
+    expect(escapeRegex("abc123")).toBe("abc123");
+    expect(escapeRegex("공지사항")).toBe("공지사항");
+    expect(escapeRegex("학사 안내")).toBe("학사 안내");
+  });
+
+  it("escapes every regex metacharacter", () => {
+    // Each metachar must be prefixed with a single backslash.
+    expect(escapeRegex(".")).toBe("\\.");
+    expect(escapeRegex("*")).toBe("\\*");
+    expect(escapeRegex("+")).toBe("\\+");
+    expect(escapeRegex("?")).toBe("\\?");
+    expect(escapeRegex("^")).toBe("\\^");
+    expect(escapeRegex("$")).toBe("\\$");
+    expect(escapeRegex("{")).toBe("\\{");
+    expect(escapeRegex("}")).toBe("\\}");
+    expect(escapeRegex("(")).toBe("\\(");
+    expect(escapeRegex(")")).toBe("\\)");
+    expect(escapeRegex("|")).toBe("\\|");
+    expect(escapeRegex("[")).toBe("\\[");
+    expect(escapeRegex("]")).toBe("\\]");
+    expect(escapeRegex("\\")).toBe("\\\\");
+  });
+
+  it("escapes mixed metachars + literal text together", () => {
+    // Input: a.b*c   →  Output: a\.b\*c  (both metachars escaped, literals
+    // kept). Verifies the escape doesn't disturb surrounding chars.
+    expect(escapeRegex("a.b*c")).toBe("a\\.b\\*c");
+  });
+
+  it("yields a literal-matching RegExp when fed user metachars", () => {
+    // The whole point of escaping: the user's `.*` should NOT match anything
+    // — it should match only the literal two-char string ".*".
+    const re = new RegExp(escapeRegex(".*"));
+    expect(re.test(".*")).toBe(true);
+    expect(re.test("anything")).toBe(false);
+    expect(re.test("a")).toBe(false);
+  });
+});
+
+describe("validateQ", () => {
+  describe("returns null for missing / empty inputs", () => {
+    it("undefined", () => {
+      expect(validateQ(undefined)).toBeNull();
+    });
+
+    it("null", () => {
+      expect(validateQ(null)).toBeNull();
+    });
+
+    it("non-string types (number / boolean / object)", () => {
+      // Express may pass arrays for repeated query params. We treat any
+      // non-string as null to keep the regex composition path total.
+      expect(validateQ(42)).toBeNull();
+      expect(validateQ(true)).toBeNull();
+      expect(validateQ({})).toBeNull();
+      expect(validateQ([])).toBeNull();
+    });
+
+    it("empty string", () => {
+      expect(validateQ("")).toBeNull();
+    });
+
+    it("whitespace-only string", () => {
+      expect(validateQ("   ")).toBeNull();
+      expect(validateQ("\t\t")).toBeNull();
+      expect(validateQ("  \n  ")).toBeNull();
+    });
+  });
+
+  describe("trims and accepts valid input", () => {
+    it("returns the same string when no surrounding whitespace", () => {
+      expect(validateQ("공지")).toBe("공지");
+      expect(validateQ("hello world")).toBe("hello world");
+    });
+
+    it("trims leading and trailing whitespace", () => {
+      expect(validateQ("  공지  ")).toBe("공지");
+      expect(validateQ("\thello\n")).toBe("hello");
+    });
+
+    it("preserves internal whitespace", () => {
+      expect(validateQ(" hello world ")).toBe("hello world");
+    });
+  });
+
+  describe("rejects control characters", () => {
+    // After trim, ASCII control chars (codepoints < 32, plus 127 DEL) are
+    // not allowed inside the query body — they're security smell (log
+    // injection / NUL truncation in some DB drivers) and have no UX value.
+    it("NUL byte", () => {
+      expect(validateQ("abc\x00def")).toBeNull();
+    });
+
+    it("internal newline", () => {
+      expect(validateQ("abc\ndef")).toBeNull();
+    });
+
+    it("internal tab", () => {
+      expect(validateQ("abc\tdef")).toBeNull();
+    });
+
+    it("DEL (codepoint 127)", () => {
+      expect(validateQ("abc\x7fdef")).toBeNull();
+    });
+
+    it("any codepoint < 32 inside body", () => {
+      // Smoke check the whole < 32 range (skip 9/10/13 which trim handles
+      // when they appear at edges only — but if internal, still rejected).
+      for (let cp = 0; cp < 32; cp++) {
+        const ch = String.fromCodePoint(cp);
+        expect(validateQ(`abc${ch}def`)).toBeNull();
+      }
+    });
+  });
+
+  describe("enforces 100-codepoint length cap (not byte / not UTF-16 unit)", () => {
+    // Korean syllables are 3 bytes in UTF-8 and 1 UTF-16 code unit. Our
+    // limit is in CODEPOINTS — 100 Korean chars must pass, 101 must fail.
+    // A naive `.length` byte/unit cap would silently allow longer strings
+    // for ASCII-heavy languages and shorter for emoji.
+    it("exact boundary 100 codepoints accepted", () => {
+      const ascii100 = "x".repeat(100);
+      const ko100 = "공".repeat(100);
+      expect(validateQ(ascii100)).toBe(ascii100);
+      expect(validateQ(ko100)).toBe(ko100);
+    });
+
+    it("101 codepoints rejected", () => {
+      expect(validateQ("x".repeat(101))).toBeNull();
+      expect(validateQ("공".repeat(101))).toBeNull();
+    });
+
+    it("emoji (surrogate pair) counted as one codepoint, not two UTF-16 units", () => {
+      // 🎉 is U+1F389 — one codepoint, two UTF-16 code units. With a
+      // codepoint cap, 100 emoji should pass; with a UTF-16 .length cap,
+      // 50 would already trigger.
+      const emoji100 = "🎉".repeat(100);
+      expect([...emoji100].length).toBe(100); // sanity check
+      expect(emoji100.length).toBe(200); // proves UTF-16 length differs
+      expect(validateQ(emoji100)).toBe(emoji100);
+    });
+
+    it("trim happens before length check", () => {
+      // 100 valid chars wrapped in whitespace must still pass — the cap
+      // applies to the trimmed value, not the raw input.
+      const padded = `   ${"x".repeat(100)}   `;
+      expect(validateQ(padded)).toBe("x".repeat(100));
+    });
+  });
+});

--- a/features/notices/notices.data.js
+++ b/features/notices/notices.data.js
@@ -9,6 +9,17 @@
 const { getClient } = require("../../lib/db");
 const config = require("../../lib/config");
 const { buildCursorFilter, encodeCursor } = require("./notices.cursor");
+const { escapeRegex } = require("./notices.search");
+
+// 4-key compound index — declared in ensureNoticeIndexes(). We .hint()
+// every query to this index to defend against the planner picking the
+// orphan 2-key sourceId_1_date_-1 index that exists on prod (undeclared
+// by app code, origin TBD). Without the hint, multi-source $in queries
+// pick the 2-key and incur an in-memory SORT stage because the sort
+// spec {date, crawledAt, _id} extends past what the 2-key covers.
+// Verified prod measurement Phase 0a 2026-04-26: with hint, multiIn
+// keysExamined drops 904 → 465 (-49%), executionTime 9ms → 3ms (-67%).
+const FORCE_INDEX = { sourceId: 1, date: -1, crawledAt: -1, _id: -1 };
 
 // Inclusion projection — lightweight list items. Heavy fields
 // (content/cleanHtml/contentText/editHistory) are intentionally omitted.
@@ -85,8 +96,19 @@ async function ensureNoticeIndexes() {
 /**
  * Shared pagination query — accepts a pre-built sourceId filter
  * (equality for single source, $in for multi-source).
+ *
+ * Optional `q` adds a case-insensitive regex $or over (title,
+ * summaryOneLiner). The regex pattern is escaped to keep user
+ * metacharacters literal. The $or is composed inside the same $and
+ * that holds the cursor keyset so no top-level $or conflict arises;
+ * MongoDB native $or treats null/missing summaryOneLiner as the second
+ * branch evaluating false, giving an automatic title-only fallback for
+ * notes whose AI summary cron hasn't filled the field yet.
  */
-async function _findNotices(sourceFilter, { cursor = null, limit, type } = {}) {
+async function _findNotices(
+  sourceFilter,
+  { cursor = null, limit, type, q } = {}
+) {
   const filter = {
     ...sourceFilter,
     isDeleted: { $ne: true },
@@ -95,12 +117,22 @@ async function _findNotices(sourceFilter, { cursor = null, limit, type } = {}) {
 
   const andClauses = [{ date: { $gte: config.notices.serviceStartDate } }];
   if (cursor) andClauses.push(buildCursorFilter(cursor));
+  if (q) {
+    const escaped = escapeRegex(q);
+    andClauses.push({
+      $or: [
+        { title: { $regex: escaped, $options: "i" } },
+        { summaryOneLiner: { $regex: escaped, $options: "i" } },
+      ],
+    });
+  }
   filter.$and = andClauses;
 
   const col = getNoticesCollection();
   const docs = await col
     .find(filter, { projection: LIST_PROJECTION })
     .sort({ date: -1, crawledAt: -1, _id: -1 })
+    .hint(FORCE_INDEX)
     .limit(limit + 1)
     .toArray();
 

--- a/features/notices/notices.routes.js
+++ b/features/notices/notices.routes.js
@@ -13,6 +13,7 @@ const {
   VALID_SUMMARY_TYPES,
 } = require("./notices.transform");
 const { decodeCursor, InvalidCursorError } = require("./notices.cursor");
+const { validateQ } = require("./notices.search");
 const sources = require("./sources");
 const tabConfig = require("./tabConfig");
 
@@ -70,11 +71,17 @@ router.get(
       }
     }
 
-    const { items, nextCursor, hasMore } = await findNoticesBySource(sourceId, {
-      cursor,
-      limit,
-      type,
-    });
+    // validateQ silently returns null for missing / empty / control-char
+    // / over-100-codepoint inputs. The data layer treats absent q as
+    // "no search clause", so we conditionally include q in opts.
+    const q = validateQ(req.query.q);
+
+    const opts = { cursor, limit, type };
+    if (q) opts.q = q;
+    const { items, nextCursor, hasMore } = await findNoticesBySource(
+      sourceId,
+      opts
+    );
     // Explicit arrow wrapper: `Array.prototype.map` passes (element, index,
     // array) — passing `toListItem` bare would leak the numeric index into
     // `toListItem`'s second `now` param and crash action_required best-pick
@@ -87,7 +94,7 @@ router.get(
   })
 );
 
-// GET /notices?sourceIds=cs,sw&limit=20&type=…&cursor=…
+// GET /notices?sourceIds=cs,sw&limit=20&type=…&cursor=…&q=…
 // Multi-source merged list — uses the existing compound index via $in.
 router.get(
   "/",
@@ -136,11 +143,16 @@ router.get(
       }
     }
 
-    const { items, nextCursor, hasMore } = await findNoticesBySources(rawIds, {
-      cursor,
-      limit,
-      type,
-    });
+    // Same validateQ contract as the single-source endpoint — null on
+    // any rejection, route omits the key so the data layer skips $or.
+    const q = validateQ(req.query.q);
+
+    const opts = { cursor, limit, type };
+    if (q) opts.q = q;
+    const { items, nextCursor, hasMore } = await findNoticesBySources(
+      rawIds,
+      opts
+    );
     const notices = items.map((doc) => toListItem(doc));
     res.success(
       { notices, nextCursor, hasMore },

--- a/features/notices/notices.search.js
+++ b/features/notices/notices.search.js
@@ -1,0 +1,51 @@
+/**
+ * Notice search helpers — pure functions, no DB.
+ *
+ * Two responsibilities:
+ *   - escapeRegex: turn user input into a literal pattern so regex
+ *     metacharacters don't broaden matches or cause ReDoS-style
+ *     pathological backtracking. The matched chars are the standard
+ *     ECMAScript regex metacharacters; backslash is escaped last so the
+ *     replacement output stays unambiguous.
+ *   - validateQ: normalize a value from req.query.q into either a
+ *     trimmed search string or null. The route layer treats null as
+ *     "no search clause" — the function NEVER throws, so the route can
+ *     compose the query unconditionally with `if (q)`.
+ *
+ * Length is measured in Unicode codepoints (`[...str].length`), not UTF-16
+ * code units (`str.length`). A naive `.length` cap allows e.g. 50 emoji
+ * (each is two code units) and rejects 100 ASCII chars at the same
+ * threshold — confusing for users in CJK / emoji-heavy queries.
+ */
+
+const MAX_QUERY_CODEPOINTS = 100;
+
+const REGEX_METACHARS = /[.*+?^${}()|[\]\\]/g;
+
+function escapeRegex(s) {
+  return s.replace(REGEX_METACHARS, "\\$&");
+}
+
+function hasControlChar(s) {
+  for (let i = 0; i < s.length; i++) {
+    const cp = s.charCodeAt(i);
+    if (cp < 32 || cp === 127) return true;
+  }
+  return false;
+}
+
+function validateQ(raw) {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  if (hasControlChar(trimmed)) return null;
+  // Codepoint count — handles surrogate pairs correctly.
+  if ([...trimmed].length > MAX_QUERY_CODEPOINTS) return null;
+  return trimmed;
+}
+
+module.exports = {
+  escapeRegex,
+  validateQ,
+  MAX_QUERY_CODEPOINTS,
+};

--- a/scripts/explain-notices-search.js
+++ b/scripts/explain-notices-search.js
@@ -1,0 +1,221 @@
+/**
+ * Phase 0a perf gate for Notice Search v1.
+ *
+ * Validates that adding a regex $or on (title, summaryOneLiner) to the
+ * existing _findNotices query does NOT break:
+ *   - sourceId equality prefix bound (ESR rule first key)
+ *   - in-memory SORT absence (index covers sort)
+ *   - executionTimeMillis budget
+ *   - selectivity (keysExamined / nReturned ratio)
+ *
+ * 3 cases (worst-case coverage):
+ *   1) single source + q              — fixed-tab search
+ *   2) multi-source $in (5 src) + q   — picker-tab worst case
+ *   3) single source + q + type       — selective summaryType filter
+ *
+ * Run:
+ *   cd skkuverse-server
+ *   NODE_ENV=production node scripts/explain-notices-search.js
+ *
+ * Read-only: only .find().explain() calls; no schema/doc writes.
+ * Exits 0 on PASS, 1 on FAIL, 2 on connection / data error.
+ */
+
+const config = require("../lib/config");
+const { getClient, closeClient } = require("../lib/db");
+
+const SEARCH_TERM = "공지"; // 매치 보장 한국어 (no zero-result false-fail)
+const TYPE_FILTER = "action_required"; // typically <10% selectivity
+const LIMIT = 21;
+
+// MUST stay in sync with notices.search.js (Phase 1) — single source of truth
+// will live there once Phase 1 lands. For 0a, replicate the regex escape.
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function findStage(plan, name) {
+  if (!plan) return null;
+  if (plan.stage === name) return plan;
+  if (plan.inputStage) return findStage(plan.inputStage, name);
+  if (plan.inputStages) {
+    for (const s of plan.inputStages) {
+      const r = findStage(s, name);
+      if (r) return r;
+    }
+  }
+  return null;
+}
+
+function buildFilter({ sourceId, sourceIds, type, q }) {
+  const filter = { isDeleted: { $ne: true } };
+  filter.sourceId = sourceIds ? { $in: sourceIds } : sourceId;
+  if (type) filter.summaryType = type;
+
+  // Mirror notices.data.js _findNotices andClauses pattern. Search $or
+  // goes INSIDE $and so it composes with cursor keyset $or without
+  // top-level conflict (plan §"$and 합성 순서").
+  const andClauses = [{ date: { $gte: config.notices.serviceStartDate } }];
+  if (q) {
+    const escaped = escapeRegex(q);
+    andClauses.push({
+      $or: [
+        { title: { $regex: escaped, $options: "i" } },
+        { summaryOneLiner: { $regex: escaped, $options: "i" } },
+      ],
+    });
+  }
+  filter.$and = andClauses;
+  return filter;
+}
+
+async function main() {
+  const client = getClient();
+  const col = client
+    .db(config.notices.dbName)
+    .collection(config.notices.collections.notices);
+
+  console.log("> NODE_ENV:", config.env);
+  console.log("> DB:", config.notices.dbName);
+  console.log("> serviceStartDate:", config.notices.serviceStartDate);
+  console.log("> search term:", JSON.stringify(SEARCH_TERM));
+  console.log("> type filter:", TYPE_FILTER);
+
+  // Find busiest sources for realistic perf measurement
+  const busiest = await col
+    .aggregate([
+      { $match: { isDeleted: { $ne: true } } },
+      { $group: { _id: "$sourceId", n: { $sum: 1 } } },
+      { $sort: { n: -1 } },
+      { $limit: 5 },
+    ])
+    .toArray();
+
+  if (busiest.length === 0) {
+    console.error("✗ No notices in DB. Re-run with NODE_ENV=production?");
+    await closeClient();
+    process.exit(2);
+  }
+
+  const top1 = busiest[0]._id;
+  const top1Count = busiest[0].n;
+  const top5 = busiest.map((b) => b._id);
+  console.log(`> busiest source: ${top1} (${top1Count} docs)`);
+  console.log(`> top5 sources: ${top5.join(", ")}`);
+
+  // Inventory all indexes — surfacing any index the app didn't declare
+  // so we know what choices the planner has.
+  const indexes = await col.indexes();
+  console.log("> indexes on collection:");
+  for (const ix of indexes) {
+    console.log(
+      `    - ${ix.name} ${JSON.stringify(ix.key)}${ix.unique ? " UNIQUE" : ""}`,
+    );
+  }
+
+  const HINT_4KEY = { sourceId: 1, date: -1, crawledAt: -1, _id: -1 };
+
+  // Every case mirrors production behavior — _findNotices unconditionally
+  // .hint()s the 4-key compound (notices.data.js FORCE_INDEX). Without
+  // this, multi-source $in falls into the orphan 2-key sourceId_1_date_-1
+  // index and incurs an in-memory SORT (Phase 0a 2026-04-26 prod measurement:
+  // unhinted multiIn → keysExamined=904, sortStage=present, time=9ms;
+  // hinted multiIn → keysExamined=465, no SORT, time=3ms). Do not remove
+  // the hint without re-running this script and observing the regression.
+  const cases = {
+    single: {
+      filter: buildFilter({ sourceId: top1, q: SEARCH_TERM }),
+      hint: HINT_4KEY,
+    },
+    multiIn: {
+      filter: buildFilter({ sourceIds: top5, q: SEARCH_TERM }),
+      hint: HINT_4KEY,
+    },
+    singleWithType: {
+      filter: buildFilter({
+        sourceId: top1,
+        type: TYPE_FILTER,
+        q: SEARCH_TERM,
+      }),
+      hint: HINT_4KEY,
+    },
+  };
+
+  let allPassed = true;
+  const summaries = {};
+  for (const [name, { filter, hint }] of Object.entries(cases)) {
+    let cursor = col.find(filter).sort({ date: -1, crawledAt: -1, _id: -1 });
+    if (hint) cursor = cursor.hint(hint);
+    const explain = await cursor.limit(LIMIT).explain("executionStats");
+
+    const plan = explain.queryPlanner.winningPlan;
+    const ix = findStage(plan, "IXSCAN");
+    const sort = findStage(plan, "SORT");
+    const stats = explain.executionStats;
+
+    const hasIxscan = !!ix;
+    const firstIxKey = ix && Object.keys(ix.keyPattern)[0];
+    const indexName = ix && ix.indexName;
+    const hasInMemorySort = !!sort;
+
+    const keysOk =
+      stats.nReturned === 0
+        ? stats.totalKeysExamined < 5000
+        : stats.totalKeysExamined / stats.nReturned < 100;
+    const timeOk = stats.executionTimeMillis < 150;
+    const ixscanOk = hasIxscan && firstIxKey === "sourceId";
+    const sortOk = !hasInMemorySort;
+
+    const passed = ixscanOk && sortOk && keysOk && timeOk;
+    if (!passed) allPassed = false;
+
+    const summary = {
+      ixscanOk,
+      firstIxKey,
+      indexName,
+      sortOk,
+      keysOk,
+      timeOk,
+      totalKeysExamined: stats.totalKeysExamined,
+      totalDocsExamined: stats.totalDocsExamined,
+      nReturned: stats.nReturned,
+      executionTimeMillis: stats.executionTimeMillis,
+      passed,
+    };
+    summaries[name] = summary;
+
+    console.log(`\n=== Case: ${name} ===`);
+    console.log(JSON.stringify(summary, null, 2));
+  }
+
+  await closeClient();
+
+  console.log("\n" + "=".repeat(50));
+  console.log(allPassed ? "✓ Phase 0a: PASS" : "✗ Phase 0a: FAIL");
+  console.log("=".repeat(50));
+
+  if (!allPassed) {
+    console.log("\nFailing cases:");
+    for (const [name, s] of Object.entries(summaries)) {
+      if (!s.passed) {
+        const reasons = [];
+        if (!s.ixscanOk) reasons.push(`firstIxKey=${s.firstIxKey} (want sourceId)`);
+        if (!s.sortOk) reasons.push("in-memory SORT present");
+        if (!s.keysOk) reasons.push(
+          s.nReturned === 0
+            ? `keysExamined=${s.totalKeysExamined} > 5000`
+            : `keys/returned=${(s.totalKeysExamined / s.nReturned).toFixed(1)} > 100`,
+        );
+        if (!s.timeOk) reasons.push(`time=${s.executionTimeMillis}ms > 150`);
+        console.log(`  ${name}: ${reasons.join(", ")}`);
+      }
+    }
+  }
+
+  process.exit(allPassed ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  closeClient().finally(() => process.exit(2));
+});


### PR DESCRIPTION
## Summary
- Adds optional `q` query parameter to `/notices/source/:sourceId` and `/notices` (multi-source). Server composes a case-insensitive `$or` regex over `(title, summaryOneLiner)` inside the existing `$and` so cursor pagination is unaffected.
- All `_findNotices` queries now `.hint()` the 4-key compound index `{sourceId, date, crawledAt, _id}` — defends against the planner picking the orphan 2-key `sourceId_1_date_-1` index that incurs an in-memory SORT on multi-source `$in` (Phase 0a prod measurement: 904→465 keys, 9ms→3ms).
- New `notices.search.js` helpers (`escapeRegex`, `validateQ` with codepoint-count length cap + control-char rejection); 22 unit tests.
- New `scripts/explain-notices-search.js` reusable verifier (read-only `.find().explain()` against prod cluster).

## Behavior
- `q` missing / empty / >100 codepoints / contains control chars → silently treated as "no search" (no 400, route just omits the clause). Client owns user-facing length feedback via debounce + min-length gating.
- `summaryOneLiner: null` notes fall back to title-only matching automatically — MongoDB native `$or` evaluates the missing-field branch as false. Strictly higher recall than title-only with zero new false negatives.
- Response shape `{ notices, nextCursor, hasMore }` unchanged → mobile clients without `q` see no behavior change.

## Test plan
- [x] 6 new integration cases on `notices-routes.test.js` (regex escape pass-through, empty q, q+cursor round-trip, q+type, etc.)
- [x] 11 new data-layer cases on `notices-data.test.js` (\$or shape, escape applied, \$and order, .hint() always called, \$in worst-case)
- [x] 22 new helper unit tests on `notices-search.test.js` (codepoint count, surrogate pair, control char rejection)
- [x] All 476 server tests pass; ESLint clean
- [x] Phase 0a verifier re-run on prod: 3/3 cases pass (single 5ms / multi-$in hinted 3ms / single+type 2ms)

## Why regex (not \$text or Atlas Search)
MongoDB CJK stemmer absent ([SERVER-29598](https://jira.mongodb.org/browse/SERVER-29598)); cluster has no Atlas Search. `sourceId` equality bounds the residual scan — verified safe at current scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)