### PR TITLE
fix(notices): CORP cross-origin override on /proxy/attachment

### DIFF
--- a/__tests__/notices-routes.test.js
+++ b/__tests__/notices-routes.test.js
@@ -347,6 +347,29 @@ describe("route ordering", () => {
 });
 
 // ──────────────────────────────────────────────────────────────────────
+// /proxy/attachment CORP override regression guard.
+//
+// The proxy is consumed cross-origin by skkuverse.com's Pages Function
+// (notice-detail web fallback) which embeds proxied images via <img>.
+// helmet's default Cross-Origin-Resource-Policy: same-origin would cause
+// browsers to refuse the embed (broken-image X). The handler explicitly
+// overrides to cross-origin at entry. This test pins that behavior so a
+// future helmet major upgrade or middleware reorder can't silently regress
+// it. Same defensive pattern as the rev 4 cache-HIT verification.
+//
+// We exercise the validation-error path (no url query) since it returns
+// 400 without needing a real upstream — Express still emits the override
+// header because res.set is called before res.error.
+// ──────────────────────────────────────────────────────────────────────
+
+describe("GET /notices/proxy/attachment — CORP cross-origin override", () => {
+  it("sets Cross-Origin-Resource-Policy: cross-origin on the response", async () => {
+    const res = await request(app).get("/notices/proxy/attachment");
+    expect(res.headers["cross-origin-resource-policy"]).toBe("cross-origin");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
 // Notice search (q parameter) — routes-level integration tests.
 // The data layer is mocked, so these tests verify the route's parsing,
 // validation, and pass-through behavior. Query-shape composition (regex

--- a/features/notices/notices.routes.js
+++ b/features/notices/notices.routes.js
@@ -169,6 +169,24 @@ router.get(
 // Fixes two upstream quirks:
 // 1. Some servers return application/unknown for .hwp — corrected via ext map
 // 2. Content-Disposition filenames are often mojibake — use client-supplied name
+//
+// Dual-use note (route name is historical; usage extends past attachments):
+//   - Mobile app: this proxy is used ONLY for attachment preview/download
+//     (NoticeDetailScreen.buildAttachmentUrl). In-article images bypass the
+//     proxy — RN's Image.getSizeWithHeaders + <Image source={{uri,headers}}>
+//     can inject Referer per-fetch directly, so SKKU origin requests work
+//     without a server hop.
+//   - Web Pages Function (skkuverse.com /p/notices/<sourceId>/<articleNo>):
+//     this proxy is used for BOTH attachment buttons AND in-article <img>
+//     src. Browsers cannot set arbitrary Referer per-image (spec limits
+//     `referrerpolicy` to enums), so the proxy hop is the only way to
+//     satisfy SKKU's hotlink check on web image embeds.
+//
+//   The CORP cross-origin override below was added when the web extension
+//   shipped — attachment-only consumers (mobile in-app browser, web
+//   <a target="_blank">) are top-level navigations untouched by CORP, so
+//   the override is invisible to them. Web <img> embeds were the only
+//   blocker; allowing cross-origin restores that one path.
 
 const EXT_MIME = {
   ".pdf": "application/pdf",

--- a/features/notices/notices.routes.js
+++ b/features/notices/notices.routes.js
@@ -281,6 +281,19 @@ function pipeDownload(upstream, res, url, name, mode) {
 router.get(
   "/proxy/attachment",
   asyncHandler(async (req, res) => {
+    // Override helmet's default Cross-Origin-Resource-Policy: same-origin for
+    // this route only. The proxy is intentionally consumed cross-origin by
+    // skkuverse.com's Pages Function (notice-detail web fallback) which embeds
+    // proxied images via <img>. Without this override, browsers receive the
+    // 200 response but refuse to render the image (CORP block, broken-image X).
+    // Mobile is unaffected — RN's Image fetcher does not enforce CORP. Other
+    // API routes remain at the helmet default since they're consumed
+    // server-to-server (mobile fetch + web Pages Function fetch), where CORP
+    // does not gate. `<a target="_blank">` and `<a href>` to this proxy are
+    // top-level navigation, also not gated by CORP, so attachment preview /
+    // download paths are unaffected by either CORP value.
+    res.set("Cross-Origin-Resource-Policy", "cross-origin");
+
     const { url, referer, mode, name } = req.query;
     if (!url) {
       return res.error(400, "INVALID_PARAMS", "url is required");


### PR DESCRIPTION
## Summary

Fix broken image rendering on the new web fallback page (`skkuverse.com/p/notices/<sourceId>/<articleNo>`). Browsers were blocking proxy `<img>` embeds with CORP `same-origin` from helmet 6.x default. Targeted route-level override at `/proxy/attachment` handler entry.

- `74dcc86` — 1-line fix: `res.set('Cross-Origin-Resource-Policy', 'cross-origin')` at handler entry; regression test pinning the header
- `0de32aa` — docs clarifying dual-use (mobile = attachment-only; web Pages Function = attachment + in-article images)

Mobile is unaffected — RN's `Image` fetcher does not enforce CORP.
Attachment preview/download paths are also unaffected — top-level navigation (`<a target=\"_blank\">`) is not gated by CORP, only embed contexts are.

## Test plan
- [x] `npm test -- __tests__/notices-routes.test.js` → 37/37 passing (incl. new CORP regression test)
- [x] `npm run lint` clean
- [x] Manual proxy curl (pre-deploy verification): `pipeDownload` uses `res.setHeader` only, no `res.writeHead` clobber → `res.set` at entry survives
- [x] CDN check: `cf-cache-status: DYNAMIC` on `files.skkuverse.com` → no cache purge needed post-deploy
- [ ] Post-deploy curl: `cross-origin-resource-policy: cross-origin` on proxy response
- [ ] Browser test: poster image renders on `https://skkuverse.com/p/notices/skku-main/136596`

🤖 Generated with [Claude Code](https://claude.com/claude-code)