### PR TITLE
feat(notices/dispatch): wire FCM push via deployed Cloud Function

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,11 @@ NAVER_API_KEY_ID=
 NAVER_API_KEY=
 NAVER_MAP_STYLE_ID=
 
+# FCM dispatch — notice push notifications via the deployed Cloud Function
+FCM_FUNCTION_URL=                          # https://asia-northeast3-skkubus-95723.cloudfunctions.net/sendNotification
+FCM_API_KEY=                               # firebase functions:secrets:get FCM_API_KEY → mirror to VM .env
+INTERNAL_DISPATCH_TOKEN=                   # shared secret with skkuverse-crawler for /internal/notices/dispatch-pending
+
 # ============================================================
 # OPTIONAL — safe literal defaults when missing
 # ============================================================
@@ -53,6 +58,15 @@ MONGO_NOTICES_COLLECTION=notices           # default: notices
 
 # Building data sync
 BUILDING_SYNC_INTERVAL_MS=                 # default: 7 days (604800000)
+
+# FCM dispatch sweep — safety-net cron for missed crawler pings
+NOTICES_DISPATCH_SWEEP_MS=                 # default: 30 min (1800000)
+DISPATCH_SWEEP_ENABLED=                    # set to "true" on the poller container only.
+                                           # Leave blank on api-1 / api-2; the ROLE=api containers
+                                           # don't startAll() pollers so the registration is harmless,
+                                           # but unset is clearer. Local dev: leave blank to avoid
+                                           # auto-firing pushes during development; the internal
+                                           # route still works for manual testing.
 
 # Firebase (auth disabled if not set — optional feature)
 FIREBASE_SERVICE_ACCOUNT=                  # JSON string of Firebase service account

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 # Environment
 *.env
 .env
+.env.bak*
 .mcp.json
 
 # OS

--- a/__tests__/notices-dispatch.test.js
+++ b/__tests__/notices-dispatch.test.js
@@ -1,0 +1,374 @@
+/**
+ * Tests for the FCM dispatch path:
+ *   - features/notices/notices.topics.js          (pure topic builder)
+ *   - features/notices/notices.dispatcher.js      (sweep + dispatchOne)
+ *   - features/notices/notices.internal.routes.js (the cycle-end ping route)
+ *   - features/notices/notices.dispatch.poller.js (env-gated cron registration)
+ *
+ * Mocking strategy mirrors notices-data.test.js: stub lib/db before any
+ * module that consumes it is required, so the dispatcher reads from our
+ * controlled `mockCollection` rather than connecting to a real Mongo.
+ */
+
+const { ObjectId } = require("mongodb");
+const express = require("express");
+const request = require("supertest");
+
+const mockCollection = {
+  findOneAndUpdate: jest.fn(),
+  updateOne: jest.fn().mockResolvedValue({ acknowledged: true }),
+};
+const mockDb = { collection: jest.fn().mockReturnValue(mockCollection) };
+const mockClient = { db: jest.fn().mockReturnValue(mockDb) };
+
+jest.mock("../lib/db", () => ({
+  getClient: jest.fn(() => mockClient),
+}));
+
+const { buildTopics } = require("../features/notices/notices.topics");
+const dispatcher = require("../features/notices/notices.dispatcher");
+const internalRoutes = require("../features/notices/notices.internal.routes");
+const config = require("../lib/config");
+
+function makeNotice(extra = {}) {
+  return {
+    _id: new ObjectId(),
+    sourceId: "skku-notice02",
+    articleNo: 1234,
+    title: "공지 제목",
+    summaryOneLiner: "한 줄 요약",
+    category: "academic",
+    aiSummaryAt: new Date("2026-05-04T01:00:00Z"),
+    pushedAt: null,
+    pushAttempts: 0,
+    pushError: null,
+    dispatchClaimedAt: null,
+    createdAt: new Date(),
+    isDeleted: false,
+    ...extra,
+  };
+}
+
+function buildInternalApp() {
+  // Mirror just enough of the prod middleware to drive the route.
+  const app = express();
+  app.use(express.json());
+  // responseHelper minimal stub — routes use res.success / res.error.
+  app.use((req, res, next) => {
+    res.success = (data) => res.json({ data });
+    res.error = (status, code, message) =>
+      res.status(status).json({ error: { code, message } });
+    next();
+  });
+  app.use("/internal/notices", internalRoutes);
+  // Surface async errors as 500s in tests. Express requires the arity-4
+  // signature to recognize this as an error handler.
+  app.use((err, req, res, next) => {
+    void next;
+    res.status(500).json({ error: { code: "TEST_ERROR", message: err.message } });
+  });
+  return app;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Reset fetch between tests; each test stubs its own behavior.
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  delete global.fetch;
+});
+
+// ──────────────────────────────────────────────────────────
+// Topic builder
+// ──────────────────────────────────────────────────────────
+describe("buildTopics", () => {
+  it("emits picker:<sourceId> for picker tab membership", () => {
+    expect(buildTopics({ sourceId: "arch" })).toContain("dept:arch");
+  });
+
+  it("emits category:<tab.id> for fixed tab membership", () => {
+    expect(buildTopics({ sourceId: "skku-notice02" })).toContain(
+      "category:academic"
+    );
+  });
+
+  it("returns [] for an unknown sourceId", () => {
+    expect(buildTopics({ sourceId: "does-not-exist" })).toEqual([]);
+  });
+
+  it("returns [] for a missing/invalid sourceId", () => {
+    expect(buildTopics({})).toEqual([]);
+    expect(buildTopics({ sourceId: null })).toEqual([]);
+    expect(buildTopics({ sourceId: 42 })).toEqual([]);
+    expect(buildTopics(null)).toEqual([]);
+  });
+
+  it("dedupes: a sourceId that maps once produces no duplicates", () => {
+    const t = buildTopics({ sourceId: "arch" });
+    expect(new Set(t).size).toBe(t.length);
+  });
+});
+
+// ──────────────────────────────────────────────────────────
+// dispatchOne
+// ──────────────────────────────────────────────────────────
+describe("dispatchOne", () => {
+  it("marks pushedAt and skips fetch when topics are empty", async () => {
+    const notice = makeNotice({ sourceId: "does-not-exist" });
+    const out = await dispatcher.dispatchOne(notice);
+    expect(out.result).toBe("skippedNoTopics");
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockCollection.updateOne).toHaveBeenCalledWith(
+      { _id: notice._id },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          pushedAt: expect.any(Date),
+          dispatchClaimedAt: null,
+        }),
+        $inc: { pushAttempts: 1 },
+      })
+    );
+  });
+
+  it("marks pushedAt and releases lease on 2xx", async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ sent: 5, failed: 0, cleanedUp: 0 }),
+    });
+
+    const notice = makeNotice();
+    const out = await dispatcher.dispatchOne(notice);
+    expect(out.result).toBe("sent");
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = global.fetch.mock.calls[0];
+    expect(url).toBe(config.notices.dispatch.functionUrl);
+    expect(opts.headers["X-API-Key"]).toBe(config.notices.dispatch.apiKey);
+    const sent = JSON.parse(opts.body);
+    expect(sent.type).toBe("notice");
+    expect(sent.noticeId).toBe(String(notice._id));
+    expect(sent.topics).toEqual(expect.arrayContaining(["category:academic"]));
+    expect(sent.title_ko).toBe(notice.title);
+    expect(sent.body_ko).toBe(notice.summaryOneLiner);
+
+    expect(mockCollection.updateOne).toHaveBeenCalledWith(
+      { _id: notice._id },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          pushedAt: expect.any(Date),
+          dispatchClaimedAt: null,
+          pushError: null,
+        }),
+        $inc: { pushAttempts: 1 },
+      })
+    );
+  });
+
+  it("records pushError, releases lease, leaves pushedAt null on 5xx", async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      text: async () => JSON.stringify({ error: "bad gateway" }),
+    });
+
+    const notice = makeNotice();
+    const out = await dispatcher.dispatchOne(notice);
+    expect(out.result).toBe("failed");
+
+    const update = mockCollection.updateOne.mock.calls[0][1];
+    expect(update.$set).toHaveProperty("dispatchClaimedAt", null);
+    expect(update.$set.pushError).toMatch(/502/);
+    expect(update.$set).not.toHaveProperty("pushedAt");
+    expect(update.$inc).toEqual({ pushAttempts: 1 });
+  });
+
+  it("treats network errors as failure and releases the lease", async () => {
+    global.fetch.mockRejectedValueOnce(new Error("ECONNRESET"));
+
+    const notice = makeNotice();
+    const out = await dispatcher.dispatchOne(notice);
+    expect(out.result).toBe("failed");
+    const update = mockCollection.updateOne.mock.calls[0][1];
+    expect(update.$set).toHaveProperty("dispatchClaimedAt", null);
+    expect(update.$set.pushError).toMatch(/ECONNRESET/);
+    expect(update.$set).not.toHaveProperty("pushedAt");
+  });
+});
+
+// ──────────────────────────────────────────────────────────
+// sweepPending
+// ──────────────────────────────────────────────────────────
+describe("sweepPending", () => {
+  function withSuccessfulFetch() {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ sent: 1, failed: 0, cleanedUp: 0 }),
+    });
+  }
+
+  it("returns processed=0 when nothing matches the claim filter", async () => {
+    mockCollection.findOneAndUpdate.mockResolvedValue(null);
+    const summary = await dispatcher.sweepPending("test");
+    expect(summary.status).toBe("ok");
+    expect(summary.processed).toBe(0);
+    expect(summary.sent).toBe(0);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("dispatches each claimed row until the queue is empty", async () => {
+    withSuccessfulFetch();
+    const a = makeNotice();
+    const b = makeNotice({ sourceId: "lib-hssc", category: undefined });
+    mockCollection.findOneAndUpdate
+      .mockResolvedValueOnce(a)
+      .mockResolvedValueOnce(b)
+      .mockResolvedValue(null);
+
+    const summary = await dispatcher.sweepPending("test");
+    expect(summary.processed).toBe(2);
+    expect(summary.sent).toBe(2);
+    expect(summary.failed).toBe(0);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("isolates per-row failures: one failure does not stop the loop", async () => {
+    const a = makeNotice();
+    const b = makeNotice();
+    mockCollection.findOneAndUpdate
+      .mockResolvedValueOnce(a)
+      .mockResolvedValueOnce(b)
+      .mockResolvedValue(null);
+
+    global.fetch
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ sent: 1, failed: 0, cleanedUp: 0 }),
+      });
+
+    const summary = await dispatcher.sweepPending("test");
+    expect(summary.processed).toBe(2);
+    expect(summary.sent).toBe(1);
+    expect(summary.failed).toBe(1);
+  });
+
+  it("supports the legacy {value} return shape from findOneAndUpdate", async () => {
+    withSuccessfulFetch();
+    const notice = makeNotice();
+    mockCollection.findOneAndUpdate
+      .mockResolvedValueOnce({ value: notice, lastErrorObject: {}, ok: 1 })
+      .mockResolvedValue(null);
+    const summary = await dispatcher.sweepPending("test");
+    expect(summary.processed).toBe(1);
+    expect(summary.sent).toBe(1);
+  });
+
+  it("submits the configured filter to findOneAndUpdate (gate fields)", async () => {
+    mockCollection.findOneAndUpdate.mockResolvedValue(null);
+    await dispatcher.sweepPending("test");
+    const [filter, update] = mockCollection.findOneAndUpdate.mock.calls[0];
+    expect(filter.pushedAt).toBeNull();
+    // partial-index-friendly form: matches the partialFilterExpression on
+    // `dispatch_pending_idx` exactly so the planner uses the index.
+    expect(filter.aiSummaryAt).toEqual({ $type: "date" });
+    expect(filter.pushAttempts).toEqual({
+      $lt: config.notices.dispatch.maxAttempts,
+    });
+    expect(filter.createdAt.$gt).toBeInstanceOf(Date);
+    expect(filter.$or).toEqual(
+      expect.arrayContaining([
+        { dispatchClaimedAt: null },
+        { dispatchClaimedAt: { $exists: false } },
+        expect.objectContaining({ dispatchClaimedAt: { $lt: expect.any(Date) } }),
+      ])
+    );
+    expect(update.$set.dispatchClaimedAt).toBeInstanceOf(Date);
+  });
+
+  it("respects sweepBatchCap as the per-tick blast-radius cap", async () => {
+    const original = config.notices.dispatch.sweepBatchCap;
+    config.notices.dispatch.sweepBatchCap = 2;
+    try {
+      withSuccessfulFetch();
+      mockCollection.findOneAndUpdate.mockImplementation(async () =>
+        makeNotice()
+      );
+      const summary = await dispatcher.sweepPending("test");
+      expect(summary.processed).toBe(2);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    } finally {
+      config.notices.dispatch.sweepBatchCap = original;
+    }
+  });
+});
+
+// ──────────────────────────────────────────────────────────
+// Internal route
+// ──────────────────────────────────────────────────────────
+describe("POST /internal/notices/dispatch-pending", () => {
+  it("rejects requests with a missing token", async () => {
+    const app = buildInternalApp();
+    const res = await request(app)
+      .post("/internal/notices/dispatch-pending")
+      .send({ source: "test" });
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects requests with a wrong token (constant-time)", async () => {
+    const app = buildInternalApp();
+    const res = await request(app)
+      .post("/internal/notices/dispatch-pending")
+      .set("X-Internal-Token", "wrong-token")
+      .send({});
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the sweep summary on the happy path", async () => {
+    mockCollection.findOneAndUpdate.mockResolvedValue(null);
+    const app = buildInternalApp();
+    const res = await request(app)
+      .post("/internal/notices/dispatch-pending")
+      .set("X-Internal-Token", config.notices.dispatch.internalToken)
+      .send({ source: "crawler-main", cycleId: "abc" });
+    expect(res.status).toBe(200);
+    expect(res.body.data.status).toBe("ok");
+    expect(res.body.data.source).toBe("crawler-main");
+    expect(res.body.data.processed).toBe(0);
+  });
+});
+
+// ──────────────────────────────────────────────────────────
+// Cron poller registration gate
+// ──────────────────────────────────────────────────────────
+describe("notices.dispatch.poller registration", () => {
+  it("skips registerPoller when DISPATCH_SWEEP_ENABLED is unset", () => {
+    jest.isolateModules(() => {
+      const pollers = require("../lib/pollers");
+      const spy = jest.spyOn(pollers, "registerPoller");
+      delete process.env.DISPATCH_SWEEP_ENABLED;
+      require("../features/notices/notices.dispatch.poller");
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  });
+
+  it("registers when DISPATCH_SWEEP_ENABLED=true", () => {
+    jest.isolateModules(() => {
+      const pollers = require("../lib/pollers");
+      const spy = jest.spyOn(pollers, "registerPoller");
+      process.env.DISPATCH_SWEEP_ENABLED = "true";
+      require("../features/notices/notices.dispatch.poller");
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [, intervalMs, name] = spy.mock.calls[0];
+      expect(intervalMs).toBe(config.notices.dispatch.sweepCronIntervalMs);
+      expect(name).toBe("notices-dispatch-sweep");
+      delete process.env.DISPATCH_SWEEP_ENABLED;
+      spy.mockRestore();
+    });
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       - NODE_ENV=production
       - ROLE=poller
       - TZ=Asia/Seoul
+      # Safety-net cron for FCM dispatch — only the poller container runs it.
+      # Primary trigger is the crawler's cycle-end ping to /internal/notices/dispatch-pending.
+      - DISPATCH_SWEEP_ENABLED=true
     restart: unless-stopped
     mem_limit: 256m
     cpus: 0.5

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,9 @@ module.exports = [
         setInterval: "readonly",
         clearTimeout: "readonly",
         clearInterval: "readonly",
+        // Node 18+ globals
+        fetch: "readonly",
+        AbortController: "readonly",
       },
     },
     rules: {

--- a/features/notices/notices.dispatch.poller.js
+++ b/features/notices/notices.dispatch.poller.js
@@ -1,0 +1,42 @@
+/**
+ * Safety-net cron sweep for FCM dispatch.
+ *
+ * Primary trigger is the crawler's cycle-end ping to the internal route.
+ * This cron exists only to recover when that ping is lost (network blip,
+ * crawler crash before ping, server restart in flight, etc.). Cadence is
+ * configurable via NOTICES_DISPATCH_SWEEP_MS (default 30 min) and is
+ * deliberately slow so it doesn't compete with the ping for normal runs.
+ *
+ * Registration is gated by DISPATCH_SWEEP_ENABLED=true so api-only pods
+ * never even register this poller. The pollers module already guards
+ * against overlapping ticks, and `sweepPending` enforces in-process
+ * single-flight + cross-instance atomic claim, so multiple replicas
+ * accidentally enabled would not double-dispatch — but they would double
+ * the read load on `notices`, which is wasteful.
+ */
+
+const config = require("../../lib/config");
+const logger = require("../../lib/logger");
+const pollers = require("../../lib/pollers");
+const { sweepPending } = require("./notices.dispatcher");
+
+if (process.env.DISPATCH_SWEEP_ENABLED === "true") {
+  pollers.registerPoller(
+    async () => {
+      try {
+        await sweepPending("cron");
+      } catch (err) {
+        logger.error(
+          { err: err && err.message ? err.message : String(err) },
+          "[dispatch] cron sweep failed"
+        );
+      }
+    },
+    config.notices.dispatch.sweepCronIntervalMs,
+    "notices-dispatch-sweep"
+  );
+} else {
+  logger.debug(
+    "[dispatch] DISPATCH_SWEEP_ENABLED not set; safety-net cron disabled (ping-only mode)"
+  );
+}

--- a/features/notices/notices.dispatcher.js
+++ b/features/notices/notices.dispatcher.js
@@ -1,0 +1,233 @@
+/**
+ * FCM dispatch via the deployed `sendNotification` Cloud Function.
+ *
+ * The notice doc itself is the outbox. Two callers (the internal route
+ * fired by the crawler's cycle-end ping, and the safety-net cron poller)
+ * both invoke `sweepPending`. The work is identical: atomically claim
+ * each push-ready row via `findOneAndUpdate`, then POST the function URL.
+ *
+ * Concurrency:
+ *   - Cross-instance: enforced by `dispatchClaimedAt` lease in Mongo.
+ *   - In-process:    enforced by `sweepInFlight` below — a second concurrent
+ *                    sweep on the same instance returns immediately, leaving
+ *                    the in-flight sweep to drain.
+ */
+
+const config = require("../../lib/config");
+const logger = require("../../lib/logger");
+const { getNoticesCollection } = require("./notices.data");
+const { buildTopics } = require("./notices.topics");
+
+let sweepInFlight = false;
+
+function buildPayload(notice, topics) {
+  const titleKo = notice.title || "";
+  const bodyKo = notice.summaryOneLiner || "";
+  const payload = {
+    type: "notice",
+    noticeId: String(notice._id),
+    topics,
+    title_ko: titleKo,
+    body_ko: bodyKo,
+    title_en: null,
+    body_en: null,
+  };
+  if (notice.sourceId) payload.sourceId = notice.sourceId;
+  if (notice.articleNo != null) payload.articleNo = String(notice.articleNo);
+  if (notice.category) payload.category = notice.category;
+  return payload;
+}
+
+async function postToFunction(payload) {
+  const { functionUrl, apiKey, fcmTimeoutMs } = config.notices.dispatch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), fcmTimeoutMs);
+  try {
+    const res = await fetch(functionUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": apiKey,
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    const text = await res.text();
+    let body = null;
+    try {
+      body = text ? JSON.parse(text) : null;
+    } catch {
+      body = { raw: text };
+    }
+    if (!res.ok) {
+      const err = new Error(
+        `sendNotification ${res.status}: ${typeof body === "object" ? JSON.stringify(body) : text}`
+      );
+      err.status = res.status;
+      throw err;
+    }
+    return body || {};
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function dispatchOne(notice) {
+  const col = getNoticesCollection();
+  const topics = buildTopics(notice);
+
+  if (topics.length === 0) {
+    // Nothing subscribable — mark resolved so sweep stops re-claiming.
+    await col.updateOne(
+      { _id: notice._id },
+      {
+        $set: {
+          pushedAt: new Date(),
+          dispatchClaimedAt: null,
+          pushError: null,
+        },
+        $inc: { pushAttempts: 1 },
+      }
+    );
+    logger.info(
+      { noticeId: String(notice._id), sourceId: notice.sourceId },
+      "[dispatch] skipped: no topics"
+    );
+    return { result: "skippedNoTopics" };
+  }
+
+  const payload = buildPayload(notice, topics);
+  try {
+    const fnResponse = await postToFunction(payload);
+    await col.updateOne(
+      { _id: notice._id },
+      {
+        $set: {
+          pushedAt: new Date(),
+          dispatchClaimedAt: null,
+          pushError: null,
+        },
+        $inc: { pushAttempts: 1 },
+      }
+    );
+    logger.info(
+      {
+        noticeId: payload.noticeId,
+        topics: topics.length,
+        sent: fnResponse.sent,
+        failed: fnResponse.failed,
+        cleanedUp: fnResponse.cleanedUp,
+      },
+      "[dispatch] sent"
+    );
+    return { result: "sent", fnResponse };
+  } catch (err) {
+    // Always release the lease so the next sweep can retry within attempts cap.
+    await col.updateOne(
+      { _id: notice._id },
+      {
+        $set: {
+          dispatchClaimedAt: null,
+          pushError: String(err && err.message ? err.message : err).slice(0, 500),
+        },
+        $inc: { pushAttempts: 1 },
+      }
+    );
+    logger.warn(
+      { noticeId: payload.noticeId, topics: topics.length, err: err && err.message },
+      "[dispatch] failed"
+    );
+    return { result: "failed", error: err };
+  }
+}
+
+async function claimNext(col, now) {
+  const { maxAgeMs, claimLeaseMs, maxAttempts } = config.notices.dispatch;
+  // `aiSummaryAt: { $type: "date" }` is the same as "$ne: null" for our schema
+  // (the field is only ever null or a Date) and matches the partialFilterExpression
+  // on `dispatch_pending_idx` exactly so the planner can use the partial index
+  // instead of a collection scan. MongoDB partial indexes do not support $ne.
+  return col.findOneAndUpdate(
+    {
+      pushedAt: null,
+      aiSummaryAt: { $type: "date" },
+      createdAt: { $gt: new Date(now.getTime() - maxAgeMs) },
+      pushAttempts: { $lt: maxAttempts },
+      isDeleted: { $ne: true },
+      $or: [
+        { dispatchClaimedAt: null },
+        { dispatchClaimedAt: { $exists: false } },
+        { dispatchClaimedAt: { $lt: new Date(now.getTime() - claimLeaseMs) } },
+      ],
+    },
+    { $set: { dispatchClaimedAt: new Date() } },
+    { returnDocument: "after" }
+  );
+}
+
+async function sweepPending(triggerSource) {
+  if (sweepInFlight) {
+    return {
+      status: "in-progress",
+      source: triggerSource,
+      processed: 0,
+      sent: 0,
+      failed: 0,
+      skippedNoTopics: 0,
+    };
+  }
+  sweepInFlight = true;
+  const startedAt = Date.now();
+  let processed = 0;
+  let sent = 0;
+  let failed = 0;
+  let skippedNoTopics = 0;
+
+  try {
+    const col = getNoticesCollection();
+    const { sweepBatchCap } = config.notices.dispatch;
+
+    while (processed < sweepBatchCap) {
+      const claimed = await claimNext(col, new Date());
+      // Driver shape: in mongodb v6 `findOneAndUpdate` returns the doc directly
+      // (or null). In some older configurations it returns `{ value, ... }`.
+      // Support both.
+      const notice =
+        claimed && typeof claimed === "object" && "value" in claimed
+          ? claimed.value
+          : claimed;
+      if (!notice) break;
+
+      processed += 1;
+      const outcome = await dispatchOne(notice);
+      if (outcome.result === "sent") sent += 1;
+      else if (outcome.result === "skippedNoTopics") skippedNoTopics += 1;
+      else failed += 1;
+    }
+
+    const summary = {
+      status: "ok",
+      source: triggerSource,
+      processed,
+      sent,
+      failed,
+      skippedNoTopics,
+      durationMs: Date.now() - startedAt,
+    };
+    if (processed > 0) {
+      logger.info(summary, "[dispatch] sweep complete");
+    } else {
+      logger.debug(summary, "[dispatch] sweep complete (empty)");
+    }
+    return summary;
+  } finally {
+    sweepInFlight = false;
+  }
+}
+
+module.exports = {
+  sweepPending,
+  dispatchOne,
+  // Exported for tests only.
+  __testInternals: { buildPayload, claimNext },
+};

--- a/features/notices/notices.internal.routes.js
+++ b/features/notices/notices.internal.routes.js
@@ -1,0 +1,53 @@
+/**
+ * Internal-only routes for the notices feature.
+ *
+ * The crawler pings POST /internal/notices/dispatch-pending at the end of
+ * each crawl cycle. The handler scans for push-ready, un-dispatched
+ * notices and fans them out via the deployed sendNotification Cloud
+ * Function. The body is metadata-only (source/cycleId/crawledAt) and is
+ * used solely for log correlation; the work is the sweep itself.
+ *
+ * Auth: shared secret in the X-Internal-Token header, compared in
+ * constant time. No Firebase auth here — the caller is the crawler
+ * service, not an end user.
+ */
+
+const express = require("express");
+const crypto = require("crypto");
+const router = express.Router();
+const asyncHandler = require("../../lib/asyncHandler");
+const config = require("../../lib/config");
+const logger = require("../../lib/logger");
+const { sweepPending } = require("./notices.dispatcher");
+
+function tokensMatch(provided, expected) {
+  if (typeof provided !== "string" || typeof expected !== "string") return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
+router.post(
+  "/dispatch-pending",
+  asyncHandler(async (req, res) => {
+    const expected = config.notices.dispatch.internalToken;
+    const provided = req.get("x-internal-token");
+    if (!tokensMatch(provided, expected)) {
+      return res.error(401, "UNAUTHORIZED", "invalid or missing X-Internal-Token");
+    }
+
+    const body = req.body || {};
+    const triggerSource =
+      typeof body.source === "string" && body.source ? body.source : "internal";
+    logger.debug(
+      { source: triggerSource, cycleId: body.cycleId, crawledAt: body.crawledAt },
+      "[dispatch] ping received"
+    );
+
+    const summary = await sweepPending(triggerSource);
+    return res.success(summary);
+  })
+);
+
+module.exports = router;

--- a/features/notices/notices.topics.js
+++ b/features/notices/notices.topics.js
@@ -1,0 +1,37 @@
+/**
+ * Maps a notice document to the set of FCM topic strings it should be pushed to.
+ *
+ * Topic format mirrors the convention emitted by the `onPreferencesWrite`
+ * Cloud Function so the function's `array-contains-any` query in Firestore
+ * matches without any translation step:
+ *   - fixed tab whose sourceId === notice.sourceId  → `category:<tab.id>`
+ *   - picker tab whose sourceIds  includes the same → `<tab.id>:<notice.sourceId>`
+ *
+ * Pure / no I/O. Reads the validated, frozen categories from tabConfig.
+ */
+
+const { categories } = require("./tabConfig");
+
+const TOPIC_CAP = 10; // sendNotification function rejects > 10.
+
+function buildTopics(noticeDoc) {
+  const sourceId = noticeDoc && noticeDoc.sourceId;
+  if (!sourceId || typeof sourceId !== "string") return [];
+
+  const out = new Set();
+  for (const cat of categories) {
+    if (cat.tabMode === "fixed") {
+      if (cat.sourceId === sourceId) {
+        out.add(`category:${cat.id}`);
+      }
+    } else if (cat.tabMode === "picker") {
+      if (Array.isArray(cat.sourceIds) && cat.sourceIds.includes(sourceId)) {
+        out.add(`${cat.id}:${sourceId}`);
+      }
+    }
+    if (out.size >= TOPIC_CAP) break;
+  }
+  return Array.from(out);
+}
+
+module.exports = { buildTopics, TOPIC_CAP };

--- a/features/notices/tabConfig.js
+++ b/features/notices/tabConfig.js
@@ -231,4 +231,10 @@ const responseByLang = Object.freeze({
   en: Object.freeze(buildTabsResponse("en")),
 });
 
-module.exports = { responseByLang, sourceMap };
+// Frozen view of the validated category definitions, exposed for callers that
+// need to reverse-map a sourceId onto its tab(s) — e.g. the FCM dispatcher
+// computing topics for a notice. Validation already ran above, so consumers
+// can trust shape: { id, tabMode: "fixed"|"picker", sourceId? | sourceIds[] }.
+const categories = Object.freeze(rawCategories.map((c) => Object.freeze(c)));
+
+module.exports = { responseByLang, sourceMap, categories };

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const { ensureIndexes, seedIfEmpty } = require("./features/ad/ad.data");
 const { ensureScheduleIndexes } = require("./features/bus/schedule-db");
 const { ensureIndexes: ensureBuildingIndexes } = require("./features/building/building.data");
 require("./features/building/building.sync"); // poller registration (side-effect)
+require("./features/notices/notices.dispatch.poller"); // poller registration (side-effect, env-gated)
 const busCache = require("./lib/busCache");
 
 let swaggerFile;
@@ -105,6 +106,7 @@ const mapMarkersRoutes = require("./features/map/map-markers.routes");
 const mapOverlaysRoutes = require("./features/map/map-overlays.routes");
 const buildingRoutes = require("./features/building/building.routes");
 const noticesRoute = require("./features/notices/notices.routes");
+const noticesInternalRoute = require("./features/notices/notices.internal.routes");
 const { ensureNoticeIndexes } = require("./features/notices/notices.data");
 
 const noticesLimiter = rateLimit({
@@ -131,6 +133,10 @@ app.use("/map/markers", generalLimiter, mapMarkersRoutes);
 app.use("/map/overlays", generalLimiter, mapOverlaysRoutes);
 app.use("/building", generalLimiter, buildingRoutes);
 app.use("/notices", verifyToken, noticesLimiter, noticesRoute);
+// Internal-only — auth via shared X-Internal-Token header inside the route.
+// Skips Firebase verifyToken (caller is the crawler service, not an end user)
+// and the noticesLimiter (single ping per crawl cycle).
+app.use("/internal/notices", noticesInternalRoute);
 
 // 404 handler (after all routes, before error handler)
 app.use((req, res) => {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -32,6 +32,9 @@ const defaults = {
   MONGO_DB_NAME_JAIN_WEEKDAY: "JAIN_weekday",
   MONGO_DB_NAME_JAIN_FRIDAY: "JAIN_friday",
   MONGO_DB_NAME_JAIN_WEEKEND: "JAIN_weekend",
+  FCM_FUNCTION_URL: "http://test-fcm-function/sendNotification",
+  FCM_API_KEY: "test-fcm-api-key",
+  INTERNAL_DISPATCH_TOKEN: "test-internal-dispatch-token",
 };
 
 for (const [key, value] of Object.entries(defaults)) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -78,6 +78,29 @@ const config = {
     // that must be explicit per environment — silently reverting to an old
     // date could expose notices the ops team intended to hide.
     serviceStartDate: process.env.NOTICES_SERVICE_START_DATE,
+
+    // FCM dispatch via deployed Cloud Function. Trigger is the crawler's
+    // cycle-end ping; the cron is a safety net only.
+    dispatch: {
+      functionUrl: process.env.FCM_FUNCTION_URL,
+      apiKey: process.env.FCM_API_KEY,
+      internalToken: process.env.INTERNAL_DISPATCH_TOKEN,
+      // Outer bound on push age. Older rows are abandoned to avoid spamming
+      // users with stale "new" notices after a long outage.
+      maxAgeMs: 24 * 60 * 60 * 1000,
+      // Claim lease — 10× the FCM timeout so a slow round trip won't trip
+      // a re-claim, but short enough that a crashed dispatcher's claims
+      // free up on the next sweep.
+      claimLeaseMs: 5 * 60 * 1000,
+      // Safety-net cron only. Primary trigger is the crawler ping.
+      sweepCronIntervalMs:
+        parseInt(process.env.NOTICES_DISPATCH_SWEEP_MS, 10) ||
+        30 * 60 * 1000,
+      maxAttempts: 5,
+      fcmTimeoutMs: 30 * 1000,
+      // Cap blast radius of a single sweep tick.
+      sweepBatchCap: 200,
+    },
   },
 
   firebase: {
@@ -132,6 +155,9 @@ const required = [
   ["ad.dbName", config.ad.dbName, "MONGO_AD_DB_NAME"],
   ["notices.dbName", config.notices.dbName, "MONGO_NOTICES_DB_NAME"],
   ["notices.serviceStartDate", config.notices.serviceStartDate, "NOTICES_SERVICE_START_DATE"],
+  ["notices.dispatch.functionUrl", config.notices.dispatch.functionUrl, "FCM_FUNCTION_URL"],
+  ["notices.dispatch.apiKey", config.notices.dispatch.apiKey, "FCM_API_KEY"],
+  ["notices.dispatch.internalToken", config.notices.dispatch.internalToken, "INTERNAL_DISPATCH_TOKEN"],
 ];
 
 const missing = required

--- a/scripts/migrate-notices-dispatch-init.js
+++ b/scripts/migrate-notices-dispatch-init.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * Step 0 of the FCM dispatch rollout — initialize the notices outbox state.
+ *
+ * Two side effects, in this order:
+ *   (a) createIndex `dispatch_pending_idx` — partial filter index for the
+ *       sweep query so it stays sub-millisecond as `notices` accumulates.
+ *   (b) backfill marker — set pushedAt/pushAttempts/pushError/aiSummaryAt/
+ *       dispatchClaimedAt on every existing notice doc so the first sweep
+ *       does NOT fire pushes for every historical notice.
+ *
+ * Idempotent. Re-running:
+ *   - createIndex with the same spec is a no-op (Mongo returns the existing
+ *     name without error).
+ *   - the backfill matches `pushedAt: { $exists: false }`, so a second run
+ *     finds 0 docs to update.
+ *
+ * Usage:
+ *   node scripts/migrate-notices-dispatch-init.js              # apply
+ *   node scripts/migrate-notices-dispatch-init.js --dry-run    # report only
+ *
+ * Pre-deploy: must run BEFORE crawler restart that begins setting aiSummaryAt
+ * and BEFORE the new server boots with sweep enabled. Otherwise the first
+ * sweep would interpret every existing notice as push-pending.
+ */
+require("dotenv").config();
+const { MongoClient } = require("mongodb");
+const config = require("../lib/config");
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+const PARTIAL_INDEX_NAME = "dispatch_pending_idx";
+const PARTIAL_INDEX_SPEC = { createdAt: -1 };
+// Partial filter — matches the sweep's hot predicates exactly.
+// Note: MongoDB partial indexes do NOT support $ne. We use $type: "date"
+// instead, which is semantically equivalent for our schema (aiSummaryAt is
+// only ever null or a Date) AND strictly more correct: a stray non-Date
+// value would not pollute the index. The dispatcher's sweep query mirrors
+// this `$type: "date"` predicate so the planner picks this index reliably.
+const PARTIAL_INDEX_OPTIONS = {
+  partialFilterExpression: {
+    pushedAt: null,
+    aiSummaryAt: { $type: "date" },
+  },
+  name: PARTIAL_INDEX_NAME,
+};
+
+async function main() {
+  const url = process.env.MONGO_URL;
+  if (!url) {
+    console.error("MONGO_URL not set in .env");
+    process.exit(1);
+  }
+
+  const client = new MongoClient(url);
+  await client.connect();
+  console.log("Connected to MongoDB");
+
+  const dbName = config.notices.dbName;
+  const collName = config.notices.collections.notices;
+  console.log(`Target: ${dbName}.${collName}${DRY_RUN ? "  [DRY-RUN]" : ""}`);
+
+  const col = client.db(dbName).collection(collName);
+
+  // ── 0. Pre-state snapshot ──
+  const totalBefore = await col.countDocuments({});
+  const withPushedAt = await col.countDocuments({ pushedAt: { $exists: true } });
+  const missingPushedAt = await col.countDocuments({ pushedAt: { $exists: false } });
+  const indexesBefore = await col.indexes();
+  const partialBefore = indexesBefore.find((i) => i.name === PARTIAL_INDEX_NAME);
+  console.log("Before:", {
+    totalBefore,
+    withPushedAt,
+    missingPushedAt,
+    partialIndexAlreadyExists: !!partialBefore,
+  });
+
+  // ── 1. Partial sweep index ──
+  if (partialBefore) {
+    console.log(
+      `Index "${PARTIAL_INDEX_NAME}" already exists; skipping createIndex.`,
+    );
+  } else if (DRY_RUN) {
+    console.log(
+      `[DRY-RUN] Would createIndex(${JSON.stringify(PARTIAL_INDEX_SPEC)}, ${JSON.stringify(PARTIAL_INDEX_OPTIONS)})`,
+    );
+  } else {
+    const indexName = await col.createIndex(
+      PARTIAL_INDEX_SPEC,
+      PARTIAL_INDEX_OPTIONS,
+    );
+    console.log(`Created index: ${indexName}`);
+  }
+
+  // ── 2. Backfill marker ──
+  if (missingPushedAt === 0) {
+    console.log("Nothing to backfill (all docs already have pushedAt).");
+  } else if (DRY_RUN) {
+    console.log(
+      `[DRY-RUN] Would updateMany on ${missingPushedAt} docs (set pushedAt=epoch + sibling fields).`,
+    );
+  } else {
+    const result = await col.updateMany(
+      { pushedAt: { $exists: false } },
+      {
+        $set: {
+          // Epoch sentinel so the maxAgeMs(24h) window in the sweep query
+          // excludes these forever — they were inserted before this rollout
+          // and must NEVER be retroactively pushed.
+          pushedAt: new Date(0),
+          pushAttempts: 0,
+          pushError: null,
+          // Deliberately NOT copying from the existing `summaryAt` field —
+          // that would pull historical notices into the sweep's pushable set
+          // even with an epoch pushedAt. Setting null keeps them excluded by
+          // the `aiSummaryAt: { $ne: null }` gate too. Defense in depth.
+          aiSummaryAt: null,
+          dispatchClaimedAt: null,
+        },
+      },
+    );
+    console.log("Backfill result:", {
+      matched: result.matchedCount,
+      modified: result.modifiedCount,
+    });
+  }
+
+  // ── 3. Post-state verification ──
+  const totalAfter = await col.countDocuments({});
+  const stillMissing = await col.countDocuments({ pushedAt: { $exists: false } });
+  const indexesAfter = await col.indexes();
+  const partialAfter = indexesAfter.find((i) => i.name === PARTIAL_INDEX_NAME);
+  console.log("After:", {
+    totalAfter,
+    stillMissingPushedAt: stillMissing,
+    partialIndexExists: !!partialAfter,
+    partialIndexSpec: partialAfter
+      ? { key: partialAfter.key, partialFilterExpression: partialAfter.partialFilterExpression }
+      : null,
+  });
+
+  if (!DRY_RUN) {
+    if (totalAfter !== totalBefore) {
+      console.error(`MISMATCH: doc count changed (${totalBefore} → ${totalAfter})`);
+      process.exit(1);
+    }
+    if (stillMissing !== 0) {
+      console.error(`MISMATCH: ${stillMissing} docs still missing pushedAt`);
+      process.exit(1);
+    }
+    if (!partialAfter) {
+      console.error(`MISMATCH: ${PARTIAL_INDEX_NAME} not present after run`);
+      process.exit(1);
+    }
+  }
+
+  console.log("Done.");
+  await client.close();
+}
+
+main().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Wires the server-side dispatch path between Mongo `notices` and the deployed `sendNotification` Cloud Function (project `skkubus-95723`, region `asia-northeast3`). Previously the function was deployed but no caller existed.
- **Architecture**: cycle-batch trigger + self-outbox. Crawler will POST `/internal/notices/dispatch-pending` at the end of each cycle (`X-Internal-Token` gated). `sweepPending` atomically claims push-ready rows (`pushedAt: null && aiSummaryAt: date && age < 24h && attempts < 5`) via `findOneAndUpdate` + 5-min `dispatchClaimedAt` lease, builds topics from `tabConfig.categories`, and posts each to the function. Same `sweepPending` is also called by a 30-min cron on the poller container as a safety net for lost pings.
- **Failure tolerance**: in-process mutex prevents concurrent sweeps on one instance; atomic claim handles cross-instance contention; lease expiry handles dispatcher crashes; per-row failure isolation; `sweepBatchCap=200` caps a single tick's blast radius; `AbortController(30s)` on the FCM fetch.
- **3 new fail-fast required env vars** in `lib/config.js`: `FCM_FUNCTION_URL`, `FCM_API_KEY`, `INTERNAL_DISPATCH_TOKEN`. **Already set on Oracle VM `.env`** before this merge — no crash-loop risk.
- **Step 0 already applied to prod** via `scripts/migrate-notices-dispatch-init.js`: partial-filter index `dispatch_pending_idx` created + 2694 historical notices backfilled with `pushedAt: epoch(0)` so the first sweep does NOT fire pushes for any pre-existing notice.

### Files (13)
| Kind | Path |
|---|---|
| New | `features/notices/notices.topics.js` — pure `buildTopics(notice)` reverse-mapping `sourceId` through tab config |
| New | `features/notices/notices.dispatcher.js` — `sweepPending` + `dispatchOne` (atomic claim, lease, fetch, bookkeeping) |
| New | `features/notices/notices.internal.routes.js` — `POST /internal/notices/dispatch-pending`, timing-safe token check |
| New | `features/notices/notices.dispatch.poller.js` — env-gated cron registration (only `DISPATCH_SWEEP_ENABLED=true`) |
| New | `__tests__/notices-dispatch.test.js` — 20 tests (topics, dispatchOne, sweepPending, route, registration gate) |
| New | `scripts/migrate-notices-dispatch-init.js` — Step 0 migration, idempotent + `--dry-run` |
| Edit | `lib/config.js` — `notices.dispatch` config + 3 required env vars |
| Edit | `features/notices/tabConfig.js` — expose validated `categories` for the topic builder |
| Edit | `index.js` — mount internal route + side-effect-require the poller registration |
| Edit | `.env.example` — document 5 new env vars |
| Edit | `docker-compose.yml` — `DISPATCH_SWEEP_ENABLED=true` on poller service only |
| Edit | `eslint.config.js` — add Node 18+ globals (`fetch`, `AbortController`) |
| Edit | `jest.setup.js` — baseline values for the 3 new required vars |

### Out of scope (locked, separate phases)
- Crawler-side cycle-end ping + `aiSummaryAt` write — separate Python repo (`skkuverse-crawler`)
- Cloud Functions code (already complete, deployed, untouched)
- Notice-edit republish — phase 2
- Stuck-row daily alerting (`pushAttempts >= 5`) — phase 2
- App-side `noticeId` dedupe (defense for failure mode #9) — separate app phase

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` green — 500 tests across 32 suites pass, including 20 new dispatch tests
- [x] `scripts/migrate-notices-dispatch-init.js --dry-run` against prod — verified expected 2694 docs to backfill
- [x] Migration applied to prod `skku_notices.notices` — index created, all 2694 docs marked, idempotent re-run confirmed
- [x] Oracle VM `/home/ubuntu/skkumap-server-express/.env` populated with 3 new vars (length-verified, values not exposed)
- [ ] After merge: confirm GitHub Actions deploys cleanly (boot must succeed with the new `required` array entries — already validated by env update above)
- [ ] After merge: poller container logs `[dispatch] sweep complete (empty)` debug entries on the 30-min cadence (sweep finds 0 rows until crawler ships its side)
- [ ] When crawler ships: end-to-end smoke — insert a test notice with `aiSummaryAt: now()`, ping the route, expect `{processed: 1, sent: ≥0}` and `pushedAt` flipped on the doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)