### PR TITLE
fix(notices/dispatch): use crawledAt instead of nonexistent createdAt

### DIFF
--- a/__tests__/notices-dispatch.test.js
+++ b/__tests__/notices-dispatch.test.js
@@ -43,7 +43,7 @@ function makeNotice(extra = {}) {
     pushAttempts: 0,
     pushError: null,
     dispatchClaimedAt: null,
-    createdAt: new Date(),
+    crawledAt: new Date(),
     isDeleted: false,
     ...extra,
   };
@@ -275,10 +275,13 @@ describe("sweepPending", () => {
     // partial-index-friendly form: matches the partialFilterExpression on
     // `dispatch_pending_idx` exactly so the planner uses the index.
     expect(filter.aiSummaryAt).toEqual({ $type: "date" });
+    // Age gate uses `crawledAt` (crawler-emitted) — `createdAt` does not
+    // exist on notices docs. Schema verified against prod 2026-05-04.
+    expect(filter.crawledAt).toBeDefined();
+    expect(filter.crawledAt.$gt).toBeInstanceOf(Date);
     expect(filter.pushAttempts).toEqual({
       $lt: config.notices.dispatch.maxAttempts,
     });
-    expect(filter.createdAt.$gt).toBeInstanceOf(Date);
     expect(filter.$or).toEqual(
       expect.arrayContaining([
         { dispatchClaimedAt: null },

--- a/features/notices/notices.dispatcher.js
+++ b/features/notices/notices.dispatcher.js
@@ -147,11 +147,18 @@ async function claimNext(col, now) {
   // (the field is only ever null or a Date) and matches the partialFilterExpression
   // on `dispatch_pending_idx` exactly so the planner can use the partial index
   // instead of a collection scan. MongoDB partial indexes do not support $ne.
+  //
+  // Age gate uses `crawledAt` (the crawler-emitted timestamp) — NOT `createdAt`.
+  // The notices collection is populated by skkuverse-crawler and uses
+  // `crawledAt` for "when the crawler first inserted/touched this doc".
+  // There is no `createdAt` field. Verified 2026-05-04 against a sample doc
+  // and against `notices.data.js:LIST_PROJECTION` which already references
+  // `crawledAt` for the read path.
   return col.findOneAndUpdate(
     {
       pushedAt: null,
       aiSummaryAt: { $type: "date" },
-      createdAt: { $gt: new Date(now.getTime() - maxAgeMs) },
+      crawledAt: { $gt: new Date(now.getTime() - maxAgeMs) },
       pushAttempts: { $lt: maxAttempts },
       isDeleted: { $ne: true },
       $or: [

--- a/scripts/migrate-notices-dispatch-init.js
+++ b/scripts/migrate-notices-dispatch-init.js
@@ -30,7 +30,11 @@ const config = require("../lib/config");
 const DRY_RUN = process.argv.includes("--dry-run");
 
 const PARTIAL_INDEX_NAME = "dispatch_pending_idx";
-const PARTIAL_INDEX_SPEC = { createdAt: -1 };
+// Sort key uses `crawledAt` (crawler-emitted timestamp) — NOT `createdAt`.
+// The notices collection has no `createdAt` field. Sweep query in
+// notices.dispatcher.js:claimNext uses `crawledAt` as the age gate.
+// Verified against prod doc 2026-05-04.
+const PARTIAL_INDEX_SPEC = { crawledAt: -1 };
 // Partial filter — matches the sweep's hot predicates exactly.
 // Note: MongoDB partial indexes do NOT support $ne. We use $type: "date"
 // instead, which is semantically equivalent for our schema (aiSummaryAt is
@@ -76,10 +80,39 @@ async function main() {
   });
 
   // ── 1. Partial sweep index ──
-  if (partialBefore) {
+  // Idempotent. Three cases:
+  //   (a) absent           → create
+  //   (b) present, correct → skip
+  //   (c) present, wrong key (e.g. legacy {createdAt:-1} from before the
+  //       2026-05-04 schema fix) → drop + recreate so the sort key matches
+  //       what the dispatcher's sweep query actually filters on.
+  function specsMatch(actualKey, desiredKey) {
+    const a = JSON.stringify(actualKey || {});
+    const b = JSON.stringify(desiredKey);
+    return a === b;
+  }
+
+  if (partialBefore && specsMatch(partialBefore.key, PARTIAL_INDEX_SPEC)) {
     console.log(
-      `Index "${PARTIAL_INDEX_NAME}" already exists; skipping createIndex.`,
+      `Index "${PARTIAL_INDEX_NAME}" already exists with correct spec; skipping.`,
     );
+  } else if (partialBefore) {
+    console.log(
+      `Index "${PARTIAL_INDEX_NAME}" exists with WRONG spec ${JSON.stringify(partialBefore.key)} — needs replacement.`,
+    );
+    if (DRY_RUN) {
+      console.log(
+        `[DRY-RUN] Would dropIndex("${PARTIAL_INDEX_NAME}") then recreate with ${JSON.stringify(PARTIAL_INDEX_SPEC)}`,
+      );
+    } else {
+      await col.dropIndex(PARTIAL_INDEX_NAME);
+      console.log(`Dropped legacy index: ${PARTIAL_INDEX_NAME}`);
+      const indexName = await col.createIndex(
+        PARTIAL_INDEX_SPEC,
+        PARTIAL_INDEX_OPTIONS,
+      );
+      console.log(`Recreated index: ${indexName}`);
+    }
   } else if (DRY_RUN) {
     console.log(
       `[DRY-RUN] Would createIndex(${JSON.stringify(PARTIAL_INDEX_SPEC)}, ${JSON.stringify(PARTIAL_INDEX_OPTIONS)})`,
@@ -150,6 +183,12 @@ async function main() {
     }
     if (!partialAfter) {
       console.error(`MISMATCH: ${PARTIAL_INDEX_NAME} not present after run`);
+      process.exit(1);
+    }
+    if (!specsMatch(partialAfter.key, PARTIAL_INDEX_SPEC)) {
+      console.error(
+        `MISMATCH: ${PARTIAL_INDEX_NAME} has wrong key ${JSON.stringify(partialAfter.key)} (expected ${JSON.stringify(PARTIAL_INDEX_SPEC)})`,
+      );
       process.exit(1);
     }
   }


### PR DESCRIPTION
## Summary
Hotfix for a silent bug introduced in PR #62. The sweep query referenced a `createdAt` field that does not exist in the notices collection (the crawler emits `crawledAt`). Result: every cycle's `dispatch_ping_sent` returned `processed: 0` regardless of how many notices were push-ready, because `createdAt: { $gt: ... }` against a missing field always evaluates false.

Caught at first real cycle observation: 9 notices got `aiSummaryAt` correctly populated; ping fired; but server returned `processed: 0`. MCP query against `_id: ObjectId("69f835e1...")` confirmed `crawledAt` present, `createdAt` absent. `notices.data.js:LIST_PROJECTION` already references `crawledAt` for the read path — I should have mirrored that field name from the start.

### Files (3)
| Kind | Path | Change |
|---|---|---|
| Edit | `features/notices/notices.dispatcher.js` | `claimNext` age gate: `createdAt` → `crawledAt` |
| Edit | `scripts/migrate-notices-dispatch-init.js` | Partial index sort key: `createdAt` → `crawledAt`. Added drop+recreate path so re-running on prod drops the legacy index with `{createdAt: -1}` and creates the new one with `{crawledAt: -1}`. Idempotent for greenfield runs |
| Edit | `__tests__/notices-dispatch.test.js` | Mock doc field + filter assertion |

## Migration step
After merge + deploy, re-run the migration:
```
NODE_ENV=production FCM_FUNCTION_URL=stub FCM_API_KEY=stub INTERNAL_DISPATCH_TOKEN=stub \
  node scripts/migrate-notices-dispatch-init.js --dry-run     # confirm what changes
NODE_ENV=production ... node scripts/migrate-notices-dispatch-init.js   # apply
```
Expected output: `Index "dispatch_pending_idx" exists with WRONG spec {"createdAt":-1} — needs replacement` → `Dropped legacy index` → `Recreated index: dispatch_pending_idx`.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 20 dispatch tests pass; full suite unaffected
- [ ] Post-deploy: re-run migration script on prod (drops legacy index, recreates with correct key)
- [ ] Next `:20` summary cycle: expect `dispatch_ping_sent` with `processed >= N` for any newly-summarized notices that have `pushedAt: null` and `crawledAt > now-24h`
- [ ] Sample push lands on a test device

## Why mock tests didn't catch this
Mock fixtures encode what the code expects, not what production has. The mock doc had `createdAt`, the test asserted `createdAt`, and the code used `createdAt` — internally consistent, externally wrong. The fix here doesn't add a fixture-from-prod pattern (out of scope) but the lesson is now in personal memory: sample-read one real prod doc before writing any cross-service query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)