### PR TITLE
fix(notices/dispatch): pushAttempts $not:$gte + migration re-run guard

### DIFF
--- a/__tests__/notices-dispatch.test.js
+++ b/__tests__/notices-dispatch.test.js
@@ -279,8 +279,10 @@ describe("sweepPending", () => {
     // exist on notices docs. Schema verified against prod 2026-05-04.
     expect(filter.crawledAt).toBeDefined();
     expect(filter.crawledAt.$gt).toBeInstanceOf(Date);
+    // $not:{$gte} so missing-field docs (fresh inserts) match;
+    // plain $lt would silently exclude them.
     expect(filter.pushAttempts).toEqual({
-      $lt: config.notices.dispatch.maxAttempts,
+      $not: { $gte: config.notices.dispatch.maxAttempts },
     });
     expect(filter.$or).toEqual(
       expect.arrayContaining([

--- a/features/notices/notices.dispatcher.js
+++ b/features/notices/notices.dispatcher.js
@@ -159,7 +159,12 @@ async function claimNext(col, now) {
       pushedAt: null,
       aiSummaryAt: { $type: "date" },
       crawledAt: { $gt: new Date(now.getTime() - maxAgeMs) },
-      pushAttempts: { $lt: maxAttempts },
+      // `$not: { $gte }` instead of `$lt` so missing/null pushAttempts (newly
+      // crawled docs that have never been claimed) ALSO match. `$lt` against
+      // a missing field returns false in Mongo and would silently exclude
+      // every fresh doc — Step 0 backfill only initializes pushAttempts on
+      // pre-existing docs, not on docs the crawler inserts later.
+      pushAttempts: { $not: { $gte: maxAttempts } },
       isDeleted: { $ne: true },
       $or: [
         { dispatchClaimedAt: null },

--- a/scripts/migrate-notices-dispatch-init.js
+++ b/scripts/migrate-notices-dispatch-init.js
@@ -126,8 +126,22 @@ async function main() {
   }
 
   // ── 2. Backfill marker ──
+  // The backfill is a one-time greenfield operation that marks PRE-EXISTING
+  // docs (at Step 0 time) as already-handled so the first sweep doesn't
+  // fire pushes for every historical notice. On re-runs, docs that are
+  // missing pushedAt are LEGITIMATELY push-ready (inserted by the crawler
+  // since Step 0) and must NOT be backfilled — that would silently mark
+  // them as already-pushed and they would never get a push.
+  //
+  // Guard: only run backfill when withPushedAt === 0 (true greenfield).
+  // Subsequent re-runs (e.g. for index spec drift like the 2026-05-04 fix)
+  // skip backfill regardless of how many docs lack pushedAt.
   if (missingPushedAt === 0) {
     console.log("Nothing to backfill (all docs already have pushedAt).");
+  } else if (withPushedAt > 0) {
+    console.log(
+      `Skipping backfill: ${missingPushedAt} doc(s) lack pushedAt, but ${withPushedAt} have it (greenfield backfill already done). These ${missingPushedAt} docs were inserted since Step 0 and are legitimate push candidates — leave them unmarked.`,
+    );
   } else if (DRY_RUN) {
     console.log(
       `[DRY-RUN] Would updateMany on ${missingPushedAt} docs (set pushedAt=epoch + sibling fields).`,
@@ -177,7 +191,11 @@ async function main() {
       console.error(`MISMATCH: doc count changed (${totalBefore} → ${totalAfter})`);
       process.exit(1);
     }
-    if (stillMissing !== 0) {
+    // Greenfield invariant: after a true Step-0 run, no doc should be missing
+    // pushedAt. On re-runs we deliberately leave new docs unmarked (they're
+    // legitimate push candidates), so we only enforce stillMissing===0 in the
+    // greenfield case.
+    if (withPushedAt === 0 && stillMissing !== 0) {
       console.error(`MISMATCH: ${stillMissing} docs still missing pushedAt`);
       process.exit(1);
     }


### PR DESCRIPTION
## Summary
Two fixes — **same root-cause pattern as PR #63's createdAt bug**: schema mismatch between server-side query assumptions and crawler-emitted docs.

### (1) sweep query: `pushAttempts: $lt 5` silently excludes fresh docs
After PR #63's `crawledAt` fix went live, manual ping STILL returned `processed: 0`. MCP-bisected the predicates:

| Predicate set | Match count |
|---|---:|
| `pushedAt:null + aiSummaryAt:date + crawledAt:>now-24h` | 11 ✓ |
| `+ pushAttempts:$lt:5` | 0 ✗ |
| `+ pushAttempts:$not:$gte:5` | 11 ✓ |

`$lt` against a missing field returns false. The 11 push-ready docs were inserted by the crawler **since Step 0** — they have no `pushAttempts` field at all (Step 0 backfill only initialized it on the 2694 pre-existing docs). `$not:{$gte:N}` matches missing/null AND values < N, which is the actual gate semantics we want.

### (2) migration script: re-run safety + drop+recreate
After PR #63 was deployed, I re-ran the migration on prod to drop the legacy `{createdAt:-1}` index and recreate with `{crawledAt:-1}`. The dry-run revealed it would ALSO have backfilled 19 push-ready docs (`pushedAt: null` because they're new). Caught and added a guard.

- Backfill skipped when `withPushedAt > 0` regardless of `missingPushedAt`. Re-runs cannot accidentally mark fresh docs as already-pushed.
- Post-state stillMissing check only enforced in greenfield (`withPushedAt === 0`).

### Files (3)
| Kind | Path | Change |
|---|---|---|
| Edit | `features/notices/notices.dispatcher.js` | `pushAttempts: $lt:N` → `pushAttempts: $not:{$gte:N}` |
| Edit | `__tests__/notices-dispatch.test.js` | Filter assertion updated |
| Edit | `scripts/migrate-notices-dispatch-init.js` | Backfill guard + verification adjusted (greenfield-only enforcement) |

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 20 dispatch tests pass
- [x] MCP query equivalence verified (`$not` form returns 11 vs `$lt` returning 0)
- [ ] Post-merge: deploy + manual ping → expect `processed: 11`, `sent: ≥0` (sent depends on whether any of the 11 sourceIds map to known topics in `tabConfig`)
- [ ] Wait for natural `:20` cycle → confirm steady-state operation

## Lesson
Same memory entry as PR #63: cross-service queries must verify field semantics against actual prod docs, not assumed schemas. Mock fixtures in `notices-dispatch.test.js` had `pushAttempts: 0` (assumed initialized) — only sample-reading prod caught the divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)