### PR TITLE
fix(scripts/migrate): drop legacy sourceDeptId indexes before $unset

### DIFF
--- a/scripts/migrate-source-dept-id.js
+++ b/scripts/migrate-source-dept-id.js
@@ -52,10 +52,20 @@ async function main() {
   } else if (DRY_RUN) {
     console.log(`[DRY-RUN] Would rename sourceDeptId → sourceId on ${withLegacy} docs`);
   } else {
-    // ── 2. Field rename via aggregation pipeline ──
+    // ── 2a. Drop legacy indexes FIRST ──
+    // Unique compound index `articleNo_1_sourceDeptId_1` would otherwise
+    // reject the $unset step (multiple docs end up with sourceDeptId:null,
+    // violating uniqueness). Server's ensureNoticeIndexes will recreate the
+    // new compound index on next request.
+    const preIndexes = await col.indexes();
+    const preLegacy = preIndexes.filter((i) => i.name && i.name.includes("sourceDeptId"));
+    for (const idx of preLegacy) {
+      console.log(`Dropping legacy index before update: ${idx.name}`);
+      await col.dropIndex(idx.name);
+    }
+
+    // ── 2b. Field rename via aggregation pipeline ──
     // $set copies value, $unset removes the legacy field. Atomic per doc.
-    // Equivalent to $rename operator but pipeline form is consistent with
-    // future multi-field migrations.
     const result = await col.updateMany(
       { sourceDeptId: { $exists: true } },
       [


### PR DESCRIPTION
## Summary
- Drop any index whose name contains `sourceDeptId` before the field-rename `updateMany` runs.
- Prevents the unique compound index `articleNo_1_sourceDeptId_1` from rejecting the migration once two docs collapse to `(articleNo, sourceDeptId=null)` after `$unset`.
- Server's `ensureNoticeIndexes` recreates the new `sourceId`-keyed compound index on the next request, so no index recreation is performed by the script itself.

## Test plan
- [x] `npm test` — 500/500 passing, 32 suites (local)
- [ ] Dry-run against `skkubus_dev` (`DRY_RUN=1`) to confirm legacy-index list matches expectations
- [ ] Apply against `skkubus_dev`; verify `ensureNoticeIndexes` recreates `articleNo_1_sourceId_1` on next API hit
- [ ] Apply against production `skkubus` during low-traffic window

🤖 Generated with [Claude Code](https://claude.com/claude-code)