### PR TITLE
chore(bus): update inja shuttle notice to weekend/holiday no-service

### DIFF
--- a/features/bus/service.config.js
+++ b/features/bus/service.config.js
@@ -6,14 +6,14 @@ module.exports = {
   "campus-inja": {
     nonOperatingDayDisplay: "hidden",
     notices: [
-      { style: "info", text: "26년도 1학기 인자셔틀 시간표 업데이트" },
+      { style: "info", text: "주말, 공휴일, 학교 휴일 운행 없음" },
     ],
     suspend: null,
   },
   "campus-jain": {
     nonOperatingDayDisplay: "hidden",
     notices: [
-      { style: "info", text: "26년도 1학기 인자셔틀 시간표 업데이트" },
+      { style: "info", text: "주말, 공휴일, 학교 휴일 운행 없음" },
     ],
     suspend: null,
   },


### PR DESCRIPTION
## Summary

- `campus-inja`와 `campus-jain` 두 서비스의 info 배너 문구를 정리.
- 이전: `"26년도 1학기 인자셔틀 시간표 업데이트"` (학기 알림성, 이미 의미 소진)
- 이후: `"주말, 공휴일, 학교 휴일 운행 없음"` (사용자가 매번 보면 유용한 운영 안내)
- `style: "info"` 유지 → 모바일의 기존 파란 `InfoBanner` 렌더링 그대로 재사용
- `fasttrack-inja`의 `ESKARA 기간 한정 운행` warning은 의도적으로 보존

## Test plan

- [ ] 서버 배포 후 `GET /bus/schedule/data/campus-inja/smart` → `days[].notices[0].text`가 새 문구
- [ ] `GET /bus/schedule/data/campus-jain/smart` 동일 확인
- [ ] 모바일 앱 Transit → 인자셔틀 진입 → 양방향 모두 파란 InfoBanner에 새 문구 노출
- [ ] 회귀 체크: `fasttrack-inja` 진입 시 기존 ESKARA warning 그대로

🤖 Generated with [Claude Code](https://claude.com/claude-code)