### PR TITLE
feat(notices): add 중국대학원(gsc) notice source

### DIFF
--- a/__tests__/notices-sources.test.ts
+++ b/__tests__/notices-sources.test.ts
@@ -1,8 +1,8 @@
 const sources = require("../features/notices/sources");
 
 describe("sources loader", () => {
-  it("loads 148 entries", () => {
-    expect(sources.list).toHaveLength(148);
+  it("loads 149 entries", () => {
+    expect(sources.list).toHaveLength(149);
   });
 
   it("every entry has the required shape", () => {

--- a/features/notices/categories.json
+++ b/features/notices/categories.json
@@ -132,7 +132,8 @@
       "bio-undergrad",
       "bio-grad",
       "pharm",
-      "nano"
+      "nano",
+      "gsc"
     ],
     "maxSelection": 5
   },

--- a/features/notices/sources.json
+++ b/features/notices/sources.json
@@ -1626,5 +1626,16 @@
     "excludeReason": null,
     "hasCategory": true,
     "hasAuthor": false
+  },
+  {
+    "id": "gsc",
+    "name": "중국대학원",
+    "campus": "hssc",
+    "college": "중국대학원",
+    "appCategory": "dept",
+    "crawlAvailable": true,
+    "excludeReason": null,
+    "hasCategory": true,
+    "hasAuthor": true
   }
 ]


### PR DESCRIPTION
## Summary
- 크롤러에 추가된 **중국대학원(gsc)** 공지 소스를 서버 설정에 반영
- `sources.json`: `gsc` 소스 등록 (campus `hssc`, `appCategory: dept`, `crawlAvailable: true`, `hasCategory/hasAuthor: true`)
- `categories.json`: 해당 picker 소스 목록에 `gsc` 추가
- `__tests__/notices-sources.test.ts`: 소스 개수 가드 148→149 갱신

## Test plan
- [x] `npm run lint` — 0 errors / 0 warnings
- [x] `npm test` — 574 passed
- [x] JSON 유효성 + `tabConfig.js` picker↔source 교차 검증 통과 (gsc가 양쪽에 일관 등록)

🤖 Generated with [Claude Code](https://claude.com/claude-code)