### PR TITLE
data(notices): mark cheme/nano unavailable (temporarilyUnavailable)

### DIFF
--- a/src/notices/sources.json
+++ b/src/notices/sources.json
@@ -1501,8 +1501,8 @@
     "campus": "nsc",
     "college": "공과대학",
     "appCategory": "dept",
-    "crawlAvailable": true,
-    "excludeReason": null,
+    "crawlAvailable": false,
+    "excludeReason": "temporarilyUnavailable",
     "hasCategory": false,
     "hasAuthor": false
   },
@@ -1600,8 +1600,8 @@
     "campus": "nsc",
     "college": "공과대학",
     "appCategory": "dept",
-    "crawlAvailable": true,
-    "excludeReason": null,
+    "crawlAvailable": false,
+    "excludeReason": "temporarilyUnavailable",
     "hasCategory": false,
     "hasAuthor": true
   },


### PR DESCRIPTION
Codegen sync from spencer0124/skkuverse-crawler#32. Data-only: cheme/nano → `crawlAvailable: false`, `excludeReason: "temporarilyUnavailable"`. categories.json unchanged (both stay in the dept picker as unsupported by the `crawlAvailable or excludeReason` rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)