### PR TITLE
fix(notices): raise multi-source sourceIds cap 5 → 20

### DIFF
--- a/__tests__/nest/notices/notices-routes.test.ts
+++ b/__tests__/nest/notices/notices-routes.test.ts
@@ -624,12 +624,24 @@ describe("GET /notices — multi-source search query", () => {
     expect(res.body.error.code).toBe("INVALID_PARAMS");
   });
 
-  it("returns 400 INVALID_PARAMS when more than 5 sourceIds", async () => {
+  it("returns 400 INVALID_PARAMS when more than 20 sourceIds", async () => {
+    // 21 ids. The count guard runs before the unknown-sourceId guard, so
+    // these can be bogus — that ordering is what this asserts.
+    const ids = Array.from({ length: 21 }, (_, i) => `src${i}`).join(",");
+    const res = await request(httpServer).get(`/notices?sourceIds=${ids}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_PARAMS");
+  });
+
+  it("lets 6 sourceIds past the count guard (was 400 under the old cap of 5)", async () => {
+    // Regression guard for the cap raise. Six ids used to fail the count
+    // check with INVALID_PARAMS; now they reach the validity check instead,
+    // so the error code is what proves the cap moved.
     const res = await request(httpServer).get(
       "/notices?sourceIds=a,b,c,d,e,f",
     );
     expect(res.status).toBe(400);
-    expect(res.body.error.code).toBe("INVALID_PARAMS");
+    expect(res.body.error.code).toBe("INVALID_SOURCE_ID");
   });
 
   it("returns 400 INVALID_SOURCE_ID when a sourceId is unknown", async () => {

--- a/scripts/explain-notices-search.js
+++ b/scripts/explain-notices-search.js
@@ -8,10 +8,18 @@
  *   - executionTimeMillis budget
  *   - selectivity (keysExamined / nReturned ratio)
  *
- * 3 cases (worst-case coverage):
- *   1) single source + q              — fixed-tab search
- *   2) multi-source $in (5 src) + q   — picker-tab worst case
- *   3) single source + q + type       — selective summaryType filter
+ * 5 cases (worst-case coverage):
+ *   1) single source + q               — fixed-tab search
+ *   2) multi-source $in (5 src) + q    — picker-tab worst case
+ *   3) single source + q + type        — selective summaryType filter
+ *   4) multi-source $in (20 src) + q   — app "전체" scope, matching term
+ *   5) multi-source $in (20 src) + q'  — same, term matching NOTHING
+ *
+ * Cases 4–5 gate the sourceIds cap raise 5 → 20 (notices.controller.ts
+ * MAX_MULTI_SOURCE_IDS). Case 5 is the one that matters: the regex is a
+ * post-filter, not index-covered, so a term with no matches forces the scan
+ * to exhaust all 20 merge-sorted index branches instead of short-circuiting
+ * once `limit` rows accumulate. A passing case 4 says nothing about case 5.
  *
  * Run:
  *   cd skkuverse-server
@@ -25,8 +33,15 @@ const config = require("../src/infra/config");
 const { getClient, closeClient } = require("../src/infra/db");
 
 const SEARCH_TERM = "공지"; // 매치 보장 한국어 (no zero-result false-fail)
+// Deliberately unmatchable — the worst case for a wide $in, because the scan
+// cannot stop early. Kept ASCII+Hangul nonsense so no future notice can
+// accidentally start matching it and silently turn this into a soft case.
+const NO_MATCH_TERM = "zzqx없는검색어zzqx";
 const TYPE_FILTER = "action_required"; // typically <10% selectivity
 const LIMIT = 21;
+// Mirrors NoticesController.MAX_MULTI_SOURCE_IDS. If that changes, change
+// this — the point of the case is to measure the contract's actual ceiling.
+const MAX_MULTI_SOURCE_IDS = 20;
 
 // MUST stay in sync with notices.search.js (Phase 1) — single source of truth
 // will live there once Phase 1 lands. For 0a, replicate the regex escape.
@@ -87,7 +102,7 @@ async function main() {
       { $match: { isDeleted: { $ne: true } } },
       { $group: { _id: "$sourceId", n: { $sum: 1 } } },
       { $sort: { n: -1 } },
-      { $limit: 5 },
+      { $limit: MAX_MULTI_SOURCE_IDS },
     ])
     .toArray();
 
@@ -99,9 +114,18 @@ async function main() {
 
   const top1 = busiest[0]._id;
   const top1Count = busiest[0].n;
-  const top5 = busiest.map((b) => b._id);
+  const topN = busiest.map((b) => b._id);
+  const top5 = topN.slice(0, 5);
   console.log(`> busiest source: ${top1} (${top1Count} docs)`);
   console.log(`> top5 sources: ${top5.join(", ")}`);
+  console.log(`> top${topN.length} sources (전체 scope stand-in): ${topN.join(", ")}`);
+  if (topN.length < MAX_MULTI_SOURCE_IDS) {
+    // Not fatal, but the 20-source cases are then measuring less than the
+    // contract allows — say so rather than let a green run over-promise.
+    console.log(
+      `⚠ only ${topN.length} sources have notices; cases 4-5 under-measure the ${MAX_MULTI_SOURCE_IDS}-source ceiling`,
+    );
+  }
 
   // Inventory all indexes — surfacing any index the app didn't declare
   // so we know what choices the planner has.
@@ -137,6 +161,16 @@ async function main() {
         type: TYPE_FILTER,
         q: SEARCH_TERM,
       }),
+      hint: HINT_4KEY,
+    },
+    // Cap-raise gate (5 → 20). See header note: the no-match variant is the
+    // real test, since it cannot short-circuit on `limit`.
+    multiIn20: {
+      filter: buildFilter({ sourceIds: topN, q: SEARCH_TERM }),
+      hint: HINT_4KEY,
+    },
+    multiIn20NoMatch: {
+      filter: buildFilter({ sourceIds: topN, q: NO_MATCH_TERM }),
       hint: HINT_4KEY,
     },
   };

--- a/src/notices/notices.controller.ts
+++ b/src/notices/notices.controller.ts
@@ -256,6 +256,22 @@ export class NoticesController {
 
   // GET /notices?sourceIds=cs,sw&limit=20&type=…&cursor=…&q=…
   // Multi-source merged list — uses the existing compound index via $in.
+  //
+  // The cap was originally 5, mirroring the largest picker tab's
+  // `maxSelection` in categories.json — the endpoint only ever served one
+  // picker tab's selection at a time. The app's search screen now offers an
+  // "전체" scope that unions every tab the user follows (5 fixed tabs + each
+  // picker's effective selection), which is ~8 by default and 20 if every
+  // picker is filled to its max. 20 is that ceiling, not a round number.
+  //
+  // Cost scales with the id count: $in makes one index-scan branch per
+  // source and MongoDB merge-sorts them. The `q` regex is NOT index-covered
+  // (post-filter on scanned docs), so a query matching little walks deep down
+  // every branch — that is the case the cap protects. Re-run
+  // `scripts/explain-notices-search.js` (multiIn20 / multiIn20NoMatch) before
+  // raising this further.
+  private static readonly MAX_MULTI_SOURCE_IDS = 20;
+
   @Get()
   async multi(
     @Query("sourceIds") sourceIdsQuery: unknown,
@@ -273,10 +289,11 @@ export class NoticesController {
       .split(",")
       .map((s: string) => s.trim())
       .filter(Boolean);
-    if (rawIds.length === 0 || rawIds.length > 5) {
+    const maxIds = NoticesController.MAX_MULTI_SOURCE_IDS;
+    if (rawIds.length === 0 || rawIds.length > maxIds) {
       throw new AppError(
         "INVALID_PARAMS",
-        "sourceIds: 1-5 comma-separated source IDs required",
+        `sourceIds: 1-${maxIds} comma-separated source IDs required`,
         400,
       );
     }


### PR DESCRIPTION
## 왜

`GET /notices`가 `sourceIds`를 1~5개로 제한하고 초과 시 `400 INVALID_PARAMS`를 던진다. 5는 성능 튜닝값이 아니라 **가장 큰 picker 탭의 `maxSelection` 미러** — 이 엔드포인트가 애초에 "picker 탭 하나의 선택"만 서빙하도록 설계됐기 때문이다.

앱 공지 검색 화면에 탭을 가로지르는 "전체" 스코프가 생기면서 이 계약에 막혔다 (증상: `공지를 불러오지 못했어요`).

## 20이 나온 근거

전체 스코프 합집합의 산술 상한이다. 임의의 라운드 넘버가 아니다.

```
5 (고정 탭: 학사/장학/취업/모집/행사)
+ 5 (dept maxSelection)
+ 3 (library)
+ 2 (dorm)
+ 5 (general)
= 20
```

여유가 0이라 공지 탭을 추가하거나 picker `maxSelection`을 올리면 다시 넘친다. 그래서 인라인 리터럴 대신 `MAX_MULTI_SOURCE_IDS` 상수 + 근거 주석으로 뒀다.

## 호환성

**하위 호환.** 상한은 받아들이는 범위를 넓히기만 하므로 기존 요청의 동작은 바뀌지 않는다. 현재 프로덕션에서 5개 초과를 보내는 클라이언트도 없다 (앱 변경은 아직 미배포).

## 성능

`$in`은 소스마다 인덱스 스캔 브랜치를 만들고 Mongo가 merge-sort하므로 비용이 개수에 대략 선형이다. 위험한 쪽은 `q` 정규식 — 인덱스가 아니라 **스캔 후 후처리**라, 매칭이 없으면 `limit`으로 조기 종료하지 못하고 20개 브랜치를 끝까지 훑는다.

그래서 `scripts/explain-notices-search.js`에 케이스 2개를 추가했다:

- `multiIn20` — 매칭 있는 20소스
- `multiIn20NoMatch` — **실제 게이트.** `multiIn20`이 초록이어도 이건 별개다

넓은 sourceIds를 실제로 보내는 클라이언트를 내보내기 전에:

```bash
NODE_ENV=production node scripts/explain-notices-search.js
```

## 테스트

- 기존 ">5 → 400" 테스트를 21개로 갱신
- 6개가 count 게이트를 통과해 `INVALID_SOURCE_ID`로 떨어지는지 확인하는 회귀 테스트 추가 (에러 코드가 상한이 움직였음을 증명)

로컬: `npm test` 372/372, `npm run lint` clean, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)