### PR TITLE
release: cross-repo contract integrity check + sources loginRequired

### DIFF
--- a/.contracts.lock.json
+++ b/.contracts.lock.json
@@ -1,0 +1,43 @@
+{
+  "lockVersion": 1,
+  "repo": "server",
+  "note": "Written by skkuverse_sync.py. Do not hand-edit, and never resolve a merge conflict here by hand - take either side, then re-run `pull --repo server`.",
+  "contracts": {
+    "notices.categories": {
+      "path": "src/notices/categories.json",
+      "sha256": "36e26285167b79517800f6136a1fc729445e6a2795747c4bac7fcb92b7513ce2",
+      "producer": {
+        "repo": "crawler",
+        "path": "py/generated/server-categories.json",
+        "ref": "main",
+        "commit": "b30e8a13a5dfb2c2179cc3ad2665e0b71a60c5a4",
+        "sha256": "36e26285167b79517800f6136a1fc729445e6a2795747c4bac7fcb92b7513ce2"
+      },
+      "syncedAt": "2026-08-04T10:48:30Z"
+    },
+    "notices.exclude-reasons": {
+      "path": "src/notices/exclude-reasons.json",
+      "sha256": "33d092f8c2f0d13f585a6f24660f2fd0bde38893e3a35e6c72ef277f6ec14f8c",
+      "producer": {
+        "repo": "crawler",
+        "path": "py/generated/server-exclude-reasons.json",
+        "ref": "main",
+        "commit": "b30e8a13a5dfb2c2179cc3ad2665e0b71a60c5a4",
+        "sha256": "33d092f8c2f0d13f585a6f24660f2fd0bde38893e3a35e6c72ef277f6ec14f8c"
+      },
+      "syncedAt": "2026-08-04T10:48:30Z"
+    },
+    "notices.sources": {
+      "path": "src/notices/sources.json",
+      "sha256": "738374f8c9e3f47d3dfbf3655e8c424c093fcdcb430e697c81731a8e8804e1d9",
+      "producer": {
+        "repo": "crawler",
+        "path": "py/generated/server-sources.json",
+        "ref": "main",
+        "commit": "b30e8a13a5dfb2c2179cc3ad2665e0b71a60c5a4",
+        "sha256": "738374f8c9e3f47d3dfbf3655e8c424c093fcdcb430e697c81731a8e8804e1d9"
+      },
+      "syncedAt": "2026-08-04T10:48:30Z"
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    # dev included: every feature PR targets dev (main only ever receives the
+    # release merge), so gating main alone meant this workflow never ran on
+    # the PRs that actually carry changes — a contract or test regression
+    # merged into dev and stayed invisible until release. skkuverse-crawler
+    # already fires on both for the same reason.
+    branches: [main, dev]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,23 @@ jobs:
       - run: npm ci
       - run: npm run typecheck
       - run: npm run build
+      # src/notices/*.json are vendored from skkuverse-crawler. This asserts
+      # they still match .contracts.lock.json — a hand edit, a partial copy,
+      # or a codegen copy that landed without a lock update all fail here.
+      # Offline by design: it compares against this repo's own lock, so it can
+      # never go red because someone edited a department in another repo.
+      # After `npm run build` so a JSON missing from copy-build-assets.js
+      # (present in src/, absent from dist/, container dies at boot) is caught
+      # by the same run.
+      #
+      # Cloned to RUNNER_TEMP rather than checked out into the workspace,
+      # where knip (project: **/*.{js,ts}) and depcheck would see it.
+      # No setup-python: ubuntu-latest ships python3 and the tool is
+      # stdlib-only, so this adds no npm dependency.
+      - name: Fetch contract tooling
+        run: git clone --depth 1 https://github.com/spencer0124/skkuverse "$RUNNER_TEMP/sv"
+      - name: Contract integrity
+        run: python3 "$RUNNER_TEMP/sv/tools/skkuverse_sync.py" check --repo server --root .
       - run: npm test
         env:
           NAVER_MAP_STYLE_ID: ${{ secrets.NAVER_MAP_STYLE_ID }}

--- a/.github/workflows/contracts-sync.yml
+++ b/.github/workflows/contracts-sync.yml
@@ -39,6 +39,11 @@ jobs:
         run: git clone --depth 1 https://github.com/spencer0124/skkuverse "$RUNNER_TEMP/sv"
 
       - name: Pull upstream contract state
+        # `shell: bash` is load-bearing: the implicit shell is `bash -e {0}`,
+        # which has errexit but NO pipefail, so `pull | tee` would take tee's
+        # exit status and a failing pull would look successful. Naming bash
+        # explicitly gets `bash --noprofile --norc -eo pipefail {0}`.
+        shell: bash
         run: |
           python3 "$RUNNER_TEMP/sv/tools/skkuverse_sync.py" pull --repo server --root . \
             | tee "$RUNNER_TEMP/pull.txt"

--- a/.github/workflows/contracts-sync.yml
+++ b/.github/workflows/contracts-sync.yml
@@ -1,0 +1,83 @@
+name: Contract sync
+
+# The freshness half of the contract system. `ci.yml` checks this repo's
+# vendored config against its own lock (offline, blocking); this checks the
+# lock against the producer's main and, when behind, prepares the update as a
+# ready-to-merge PR rather than a notification.
+#
+# Why a PR and not an issue: an issue is a task someone must act on, and a
+# neglected one trains you to ignore the next. A PR is a completed proposal
+# that needs a merge click, and it rides the review flow you already use.
+# Same shape as Renovate/Dependabot, minus the infrastructure.
+#
+# Fixed branch name, force-pushed, so repeated drift updates one PR instead
+# of accumulating a pile.
+on:
+  schedule:
+    - cron: '0 21 * * *'   # 06:00 KST
+  workflow_dispatch:
+
+# Elevated only here. The repo default stays read, so no other workflow gains
+# write access.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      BASE: dev
+      SYNC_BRANCH: contracts/sync
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Fetch contract tooling
+        run: git clone --depth 1 https://github.com/spencer0124/skkuverse "$RUNNER_TEMP/sv"
+
+      - name: Pull upstream contract state
+        run: |
+          python3 "$RUNNER_TEMP/sv/tools/skkuverse_sync.py" pull --repo server --root . \
+            | tee "$RUNNER_TEMP/pull.txt"
+
+      # No drift means `pull` wrote nothing at all — it rewrites a lock only
+      # when a hash actually changed, so a clean fleet produces zero diffs.
+      # That property is what keeps this workflow silent on most days.
+      - name: Stop if already in sync
+        id: drift
+        run: |
+          if git diff --quiet; then
+            echo "in sync — nothing to propose"
+            echo "drifted=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "drifted=true" >> "$GITHUB_OUTPUT"
+            git --no-pager diff --stat
+          fi
+
+      - name: Open or update the sync PR
+        if: steps.drift.outputs.drifted == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$SYNC_BRANCH"
+          git commit -am "chore(contracts): sync vendored config from upstream SSOT"
+          git push -f origin "$SYNC_BRANCH"
+
+          # The PR carries both the updated files and the updated lock, so its
+          # own integrity check is green — it is merge-ready, not a chore.
+          body="$(printf 'Upstream SSOT moved and this repo is behind. Opened automatically by `.github/workflows/contracts-sync.yml`.\n\nThe vendored files **and** `.contracts.lock.json` are both updated here, so the integrity check on this PR is green — review the diff and merge.\n\n```\n%s\n```\n\nContract definitions: https://github.com/spencer0124/skkuverse/blob/main/contracts/manifest.json\n' "$(cat "$RUNNER_TEMP/pull.txt")")"
+
+          if gh pr view "$SYNC_BRANCH" --json number >/dev/null 2>&1; then
+            gh pr edit "$SYNC_BRANCH" --body "$body"
+            echo "updated the existing sync PR"
+          else
+            gh pr create --base "$BASE" --head "$SYNC_BRANCH" \
+              --title "chore(contracts): sync vendored config from upstream SSOT" \
+              --body "$body"
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,16 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
+      # Also here, not just in ci.yml: this is the path that actually reaches
+      # prod, and a partial copy of src/notices/*.json makes TabConfigService
+      # throw at boot, so the rolling update would fail its health poll and
+      # roll back. `deploy` needs this job, so catching it here saves a
+      # deploy-and-rollback cycle. Offline, so a GitHub outage cannot block a
+      # release for a reason unrelated to it.
+      - name: Fetch contract tooling
+        run: git clone --depth 1 https://github.com/spencer0124/skkuverse "$RUNNER_TEMP/sv"
+      - name: Contract integrity
+        run: python3 "$RUNNER_TEMP/sv/tools/skkuverse_sync.py" check --repo server --root .
       - run: npm test
         env:
           NAVER_MAP_STYLE_ID: ${{ secrets.NAVER_MAP_STYLE_ID }}

--- a/src/notices/sources.json
+++ b/src/notices/sources.json
@@ -1105,8 +1105,8 @@
     "campus": "both",
     "college": null,
     "appCategory": "general",
-    "crawlAvailable": true,
-    "excludeReason": null,
+    "crawlAvailable": false,
+    "excludeReason": "loginRequired",
     "hasCategory": true,
     "hasAuthor": true
   },


### PR DESCRIPTION
Release merge. Six commits, five files — four of them CI config.

## What ships

- **`.contracts.lock.json`** + a contract integrity check in `ci.yml` and `deploy.yml`. Verifies `src/notices/*.json` still match the crawler SSOT they were vendored from. Offline, so it can never go red because someone edited a department upstream.
- **`.github/workflows/contracts-sync.yml`** — daily cron that opens a self-PR when the crawler moves ahead. GitHub only schedules from the default branch, so this merge is what starts it running.
- **`ci.yml` now fires on PRs to `dev`, not just `main`.** Every feature PR targets dev, so gating main alone meant CI never ran on the PRs that carry changes.
- **`src/notices/sources.json`** — 4 lines, the `crawlAvailable: false` / `loginRequired` flip, already live in the crawler.

No application code changes. No behavior change to any endpoint.

## Verified

Full local gate green before merge to dev: `typecheck`, `build`, `lint`, `knip`, `depcheck`, and 411 tests across 37 suites. CI passed on #84 after the tooling landed on the umbrella's `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)