### PR TITLE
feat(contracts): track TOPIC_CAP against the app's ceiling

### DIFF
--- a/.contracts.lock.json
+++ b/.contracts.lock.json
@@ -10,7 +10,7 @@
         "repo": "crawler",
         "path": "py/generated/server-categories.json",
         "ref": "main",
-        "commit": "b30e8a13a5dfb2c2179cc3ad2665e0b71a60c5a4",
+        "commit": "288239759b13d87a0ed5c671bf2521ade2bb4fce",
         "sha256": "36e26285167b79517800f6136a1fc729445e6a2795747c4bac7fcb92b7513ce2"
       },
       "syncedAt": "2026-08-04T10:48:30Z"
@@ -22,7 +22,7 @@
         "repo": "crawler",
         "path": "py/generated/server-exclude-reasons.json",
         "ref": "main",
-        "commit": "b30e8a13a5dfb2c2179cc3ad2665e0b71a60c5a4",
+        "commit": "288239759b13d87a0ed5c671bf2521ade2bb4fce",
         "sha256": "33d092f8c2f0d13f585a6f24660f2fd0bde38893e3a35e6c72ef277f6ec14f8c"
       },
       "syncedAt": "2026-08-04T10:48:30Z"
@@ -34,10 +34,25 @@
         "repo": "crawler",
         "path": "py/generated/server-sources.json",
         "ref": "main",
-        "commit": "b30e8a13a5dfb2c2179cc3ad2665e0b71a60c5a4",
+        "commit": "288239759b13d87a0ed5c671bf2521ade2bb4fce",
         "sha256": "738374f8c9e3f47d3dfbf3655e8c424c093fcdcb430e697c81731a8e8804e1d9"
       },
       "syncedAt": "2026-08-04T10:48:30Z"
+    },
+    "notices.topic-cap": {
+      "path": "src/notices/notices.topics.ts",
+      "symbol": "TOPIC_CAP",
+      "value": 30,
+      "relation": "lte",
+      "producer": {
+        "repo": "app",
+        "path": "functions/src/notifications/tabsContract.ts",
+        "symbol": "MAX_TOPICS",
+        "ref": "main",
+        "commit": "27b05436291e6fabb537eda0f8b90fdd5cb2a37a",
+        "value": 30
+      },
+      "syncedAt": "2026-08-04T13:12:48Z"
     }
   }
 }

--- a/src/notices/notices.topics.ts
+++ b/src/notices/notices.topics.ts
@@ -12,9 +12,16 @@
 import { categories } from "./tabConfig";
 import type { CategoryConfig } from "./types";
 
-// MUST stay equal to MAX_TOPICS in skkuverse-app functions/src/handle-notice.ts
-// — that function rejects a payload with more topics than its own cap, so the
-// two are a cross-repo contract and the CF must be deployed first when raising.
+// Cross-repo contract `notices.topic-cap` (skkuverse/contracts/manifest.json).
+//
+// The ceiling is MAX_TOPICS in skkuverse-app
+// functions/src/notifications/tabsContract.ts — the Cloud Function rejects any
+// payload above it. The invariant is TOPIC_CAP <= MAX_TOPICS, not equality:
+// the app must deploy first when raising (ADR 0005), and `lte` keeps that
+// intermediate state green while still catching the reverse, which is the
+// dangerous one. CI enforces it against the value recorded in
+// .contracts.lock.json — do not hand-edit that file; run
+// `skkuverse_sync.py pull --repo server`.
 //
 // 30 is Firestore's real `array-contains-any` limit. The previous 10 was a
 // self-imposed "MVP conservative limit" (see the CF's types.ts), and it became


### PR DESCRIPTION
**Step 3 of 4.** Needs spencer0124/skkuverse#2 and spencer0124/skkuverse-app#21 merged first.

## Why

`TOPIC_CAP` and skkuverse-app's `MAX_TOPICS` are a cross-repo pair, and until now the only thing holding them together was a comment on each side — one of which pointed at `functions/src/handle-notice.ts`, a file the constant had already moved out of.

## The substance: `lte`, not `eq`

The Cloud Function 400s any payload above `MAX_TOPICS`, so the danger is strictly **one-directional** — the server being *above* the app. ADR 0005 therefore mandates deploying the app first when raising, and equality would paint that mandated intermediate state red:

| app `MAX_TOPICS` | server `TOPIC_CAP` | `eq` | `lte` | actually safe? |
|---|---|---|---|---|
| 10 | 10 | green | green | yes |
| 30 | 10 | **RED** | green | yes — server sends ≤10, CF accepts ≤30 |
| 30 | 30 | green | green | yes |
| 10 | 30 | RED | **RED** | no — CF 400s, retries burn to permanent failure |

`lte` is green exactly on the safe states and red exactly on the dangerous one. It encodes the invariant instead of a snapshot.

## What changed

- `.contracts.lock.json` gains a `notices.topic-cap` entry recording the app's `MAX_TOPICS` and the commit it was read from. The check is then a pure local comparison — offline, so it runs in `deploy.yml` too.
- The comment is rewritten. It claimed the two "MUST stay equal" and cited a stale path.

Raising the cap is now: `skkuverse_sync.py pull --repo server` to refresh the locked ceiling, then raise `TOPIC_CAP` in the same PR. Two lines change, and the order is enforced.

## Verified

All four rows above, plus the rename case: renaming the constant produces **exit 2** naming the manifest field to update — fail-closed, not a silent pass. Extraction is by regex, but "I can no longer find this constant" is itself a build failure.

Full gate green: typecheck, lint, 411 tests across 37 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)