### PR TITLE
release: track TOPIC_CAP against the app's ceiling

### DIFF
--- a/.contracts.lock.json
+++ b/.contracts.lock.json
@@ -10,7 +10,7 @@
         "repo": "crawler",
         "path": "py/generated/server-categories.json",
         "ref": "main",
-        "commit": "b30e8a13a5dfb2c2179cc3ad2665e0b71a60c5a4",
+        "commit": "288239759b13d87a0ed5c671bf2521ade2bb4fce",
         "sha256": "36e26285167b79517800f6136a1fc729445e6a2795747c4bac7fcb92b7513ce2"
       },
       "syncedAt": "2026-08-04T10:48:30Z"
@@ -22,7 +22,7 @@
         "repo": "crawler",
         "path": "py/generated/server-exclude-reasons.json",
         "ref": "main",
-        "commit": "b30e8a13a5dfb2c2179cc3ad2665e0b71a60c5a4",
+        "commit": "288239759b13d87a0ed5c671bf2521ade2bb4fce",
         "sha256": "33d092f8c2f0d13f585a6f24660f2fd0bde38893e3a35e6c72ef277f6ec14f8c"
       },
       "syncedAt": "2026-08-04T10:48:30Z"
@@ -34,10 +34,25 @@
         "repo": "crawler",
         "path": "py/generated/server-sources.json",
         "ref": "main",
-        "commit": "b30e8a13a5dfb2c2179cc3ad2665e0b71a60c5a4",
+        "commit": "288239759b13d87a0ed5c671bf2521ade2bb4fce",
         "sha256": "738374f8c9e3f47d3dfbf3655e8c424c093fcdcb430e697c81731a8e8804e1d9"
       },
       "syncedAt": "2026-08-04T10:48:30Z"
+    },
+    "notices.topic-cap": {
+      "path": "src/notices/notices.topics.ts",
+      "symbol": "TOPIC_CAP",
+      "value": 30,
+      "relation": "lte",
+      "producer": {
+        "repo": "app",
+        "path": "functions/src/notifications/tabsContract.ts",
+        "symbol": "MAX_TOPICS",
+        "ref": "main",
+        "commit": "27b05436291e6fabb537eda0f8b90fdd5cb2a37a",
+        "value": 30
+      },
+      "syncedAt": "2026-08-04T13:12:48Z"
     }
   }
 }

--- a/src/notices/notices.topics.ts
+++ b/src/notices/notices.topics.ts
@@ -12,9 +12,16 @@
 import { categories } from "./tabConfig";
 import type { CategoryConfig } from "./types";
 
-// MUST stay equal to MAX_TOPICS in skkuverse-app functions/src/handle-notice.ts
-// — that function rejects a payload with more topics than its own cap, so the
-// two are a cross-repo contract and the CF must be deployed first when raising.
+// Cross-repo contract `notices.topic-cap` (skkuverse/contracts/manifest.json).
+//
+// The ceiling is MAX_TOPICS in skkuverse-app
+// functions/src/notifications/tabsContract.ts — the Cloud Function rejects any
+// payload above it. The invariant is TOPIC_CAP <= MAX_TOPICS, not equality:
+// the app must deploy first when raising (ADR 0005), and `lte` keeps that
+// intermediate state green while still catching the reverse, which is the
+// dangerous one. CI enforces it against the value recorded in
+// .contracts.lock.json — do not hand-edit that file; run
+// `skkuverse_sync.py pull --repo server`.
 //
 // 30 is Firestore's real `array-contains-any` limit. The previous 10 was a
 // self-imposed "MVP conservative limit" (see the CF's types.ts), and it became


### PR DESCRIPTION
Release merge. Two commits, two files: a lock entry and a comment.

**`TOPIC_CAP` stays 30 — no runtime value changes, no behavior changes.**

Per ADR 0005 this releases after the app side (spencer0124/skkuverse-app#22), which carries the `MAX_TOPICS` ceiling this now tracks.

## What ships

- `.contracts.lock.json` gains `notices.topic-cap`, recording the app's `MAX_TOPICS = 30` and the commit it was read from. The check is a pure local comparison, so it runs in `deploy.yml` as well as `ci.yml`.
- `src/notices/notices.topics.ts` — comment only. It claimed the two constants "MUST stay equal" and cited `functions/src/handle-notice.ts`, which no longer holds the constant. The real invariant is `TOPIC_CAP <= MAX_TOPICS`.

## Why `lte` and not `eq`

The Cloud Function 400s any payload above `MAX_TOPICS`, so the danger is one-directional. Equality would paint the mandated app-first deploy order red in the middle:

| app | server | `eq` | `lte` | safe? |
|---|---|---|---|---|
| 30 | 10 | **RED** | green | yes |
| 10 | 30 | RED | **RED** | no — CF 400s, retries burn |

## Verified

All four transition states plus the rename case (exit 2, fail-closed). Full gate green: typecheck, lint, 411 tests across 37 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)