### PR TITLE
feat(conventions): adopt the shared workspace conventions

### DIFF
--- a/.contracts.lock.json
+++ b/.contracts.lock.json
@@ -3,6 +3,18 @@
   "repo": "server",
   "note": "Written by skkuverse_sync.py. Do not hand-edit, and never resolve a merge conflict here by hand - take either side, then re-run `pull --repo server`.",
   "contracts": {
+    "conventions.markdownlint": {
+      "path": ".markdownlint.jsonc",
+      "sha256": "f416bcab34d8114516a47be53c7fd38646d0ec7fb92b41f80116f3683e4b54ef",
+      "producer": {
+        "repo": "umbrella",
+        "path": "conventions/markdownlint.jsonc",
+        "ref": "main",
+        "commit": "672a16ea65d96aa88efb517cd304da2c0487de0d",
+        "sha256": "f416bcab34d8114516a47be53c7fd38646d0ec7fb92b41f80116f3683e4b54ef"
+      },
+      "syncedAt": "2026-08-05T02:42:51Z"
+    },
     "notices.categories": {
       "path": "src/notices/categories.json",
       "sha256": "36e26285167b79517800f6136a1fc729445e6a2795747c4bac7fcb92b7513ce2",
@@ -10,7 +22,7 @@
         "repo": "crawler",
         "path": "py/generated/server-categories.json",
         "ref": "main",
-        "commit": "288239759b13d87a0ed5c671bf2521ade2bb4fce",
+        "commit": "9cf521b2869d05dffe58ad81c3af79e186ac251d",
         "sha256": "36e26285167b79517800f6136a1fc729445e6a2795747c4bac7fcb92b7513ce2"
       },
       "syncedAt": "2026-08-04T10:48:30Z"
@@ -22,7 +34,7 @@
         "repo": "crawler",
         "path": "py/generated/server-exclude-reasons.json",
         "ref": "main",
-        "commit": "288239759b13d87a0ed5c671bf2521ade2bb4fce",
+        "commit": "9cf521b2869d05dffe58ad81c3af79e186ac251d",
         "sha256": "33d092f8c2f0d13f585a6f24660f2fd0bde38893e3a35e6c72ef277f6ec14f8c"
       },
       "syncedAt": "2026-08-04T10:48:30Z"
@@ -34,7 +46,7 @@
         "repo": "crawler",
         "path": "py/generated/server-sources.json",
         "ref": "main",
-        "commit": "288239759b13d87a0ed5c671bf2521ade2bb4fce",
+        "commit": "9cf521b2869d05dffe58ad81c3af79e186ac251d",
         "sha256": "738374f8c9e3f47d3dfbf3655e8c424c093fcdcb430e697c81731a8e8804e1d9"
       },
       "syncedAt": "2026-08-04T10:48:30Z"

--- a/.conventions.json
+++ b/.conventions.json
@@ -1,0 +1,16 @@
+{
+  "_note": "Exceptions to the shared SKKUverse conventions, declared by this repo. Checked by tools/conventions_lint.py in spencer0124/skkuverse. Keep exceptions here rather than centrally, so whoever needs one declares it in the same commit as the code that needs it.",
+
+  "_productCopy": "Korean that IS the product rather than documentation. src/notices/*.json carry label.ko for department and category names; infra/i18n.ts is the server-generated UI string table. Both are data shipped to users.",
+  "productCopy": [
+    "src/infra/i18n.ts",
+    "src/notices/sources.json",
+    "src/notices/categories.json",
+    "src/notices/exclude-reasons.json"
+  ],
+
+  "frontmatterExempt": [],
+
+  "_extraDocFolders": "internal/ and archive/ are filed by lifecycle rather than by reader need, so they sit outside the Diataxis taxonomy on purpose.",
+  "extraDocFolders": []
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,18 @@ jobs:
         run: git clone --depth 1 https://github.com/spencer0124/skkuverse "$RUNNER_TEMP/sv"
       - name: Contract integrity
         run: python3 "$RUNNER_TEMP/sv/tools/skkuverse_sync.py" check --repo server --root .
+      # Shared conventions, defined once in the umbrella. Same clone, so this
+      # adds no dependency and no install step.
+      #
+      # `--only` rather than the full set: `language` fails today because the
+      # docs are still Korean, and turning the whole check off until that is
+      # finished would mean the two rules this repo ALREADY satisfies go
+      # ungated for however long the translation takes. Add `language` here
+      # when docs/ is English.
+      - name: Conventions
+        run: |
+          python3 "$RUNNER_TEMP/sv/tools/conventions_lint.py" --root . \
+            --only frontmatter --only structure
       - run: npm test
         env:
           NAVER_MAP_STYLE_ID: ${{ secrets.NAVER_MAP_STYLE_ID }}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,27 +1,20 @@
 {
-  // markdownlint-cli2 config — docs 컨벤션 게이트 (docs/README.md 참조)
+  // markdownlint-cli2 config — the docs convention gate (see docs/README.md)
   "config": {
-    "default": true,
-
-    // ── 비활성: 한국어 산문 + 자유 서식과 충돌하는 규칙 ──
-    "MD013": false, // line-length — 한국어 장문 산문에 부적합
-    "MD033": false, // inline HTML — <details>, <br> 등 허용
-    "MD024": { "siblings_only": true }, // 중복 헤딩 — 형제 레벨에서만 금지 (릴리스노트/타임라인 패턴 허용)
-    "MD036": false, // emphasis-as-heading — **강조 라벨** 관용 표현 허용
-    "MD028": false, // blanks-inside-blockquote — `> 요약` 다음 `> [!NOTE]` 인접 패턴이 스키마 골격이라 허용
-
-    // ── 핵심 강제 규칙 (명시적으로 기록; default true지만 의도 표시) ──
-    "MD001": true, // 헤딩 레벨 건너뛰기 금지
-    "MD003": { "style": "atx" }, // # 스타일 헤딩만
-    "MD025": { "front_matter_title": "" }, // H1은 문서당 하나 — frontmatter title은 헤딩으로 세지 않음 (스키마상 title+H1 공존)
-    "MD040": true, // 코드펜스 언어 태그 필수
-    "MD041": false // 첫 줄 H1 요구 — frontmatter 뒤 인용 요약 패턴과 충돌 시 대비
+    // Rules come from .markdownlint.jsonc, vendored from the umbrella by the
+    // `conventions.markdownlint` contract and hash-locked in
+    // .contracts.lock.json. Do not edit that file — edit
+    // skkuverse/conventions/markdownlint.jsonc and run `skkuverse_sync.py pull`.
+    //
+    // Rules central, globs local: which paths this repo lints is genuinely
+    // repo-specific and stays below.
+    "extends": ".markdownlint.jsonc"
   },
 
-  // Flagship-first: Diátaxis로 이관된 문서 + 프레임워크 문서만 게이트.
-  // 미이관 레거시 flat 문서(project-docs.md 등)는 아래 ignores로 유예 —
-  // 이 목록이 곧 마이그레이션 TODO다 (docs/README.md "이관 backlog" 참조).
-  // 문서를 Diátaxis로 분해할 때마다 여기서 한 줄씩 제거한다.
+  // Flagship-first: only documents already migrated to Diataxis are gated.
+  // Legacy flat documents are deferred via `ignores` below, and that list IS
+  // the migration backlog — delete a line from it each time a document is
+  // broken out into the taxonomy.
   "globs": ["docs/**/*.md"],
   "gitignore": true,
   "ignores": [

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,40 @@
+// Canonical markdownlint rules for every SKKUverse repository.
+//
+// Vendored into each repo as `.markdownlint.jsonc` by the contract
+// `conventions.markdownlint` and hash-locked, so a repo cannot drift from it
+// without CI saying so. Do not edit the vendored copies — edit this file and
+// run `skkuverse_sync.py pull --all`.
+//
+// RULES ARE CENTRAL, GLOBS ARE LOCAL. This file carries only the rule set;
+// each repo keeps its own `.markdownlint-cli2.jsonc` naming which paths to
+// lint and which to skip, because those are genuinely repo-specific
+// (`docs/**` in one repo, `**/*.md` minus an Expo build tree in another).
+// That split is why the two existing copies were byte-identical everywhere
+// except `globs` and `ignores`.
+//
+// Consume it like this:
+//
+//     // .markdownlint-cli2.jsonc
+//     {
+//       "config": { "extends": ".markdownlint.jsonc" },
+//       "globs": ["docs/**/*.md"],
+//       "ignores": ["**/CHANGELOG.md"]
+//     }
+{
+  "default": true,
+
+  // ── Disabled: rules that fight this workspace's prose style ──
+  "MD013": false, // line-length — prose is wrapped by meaning, not column count
+  "MD033": false, // inline HTML — <details> and <br> are used deliberately
+  "MD024": { "siblings_only": true }, // duplicate headings — banned only among siblings, so release-note and timeline patterns work
+  "MD036": false, // emphasis-as-heading — **bold labels** are an accepted idiom here
+  "MD028": false, // blanks-inside-blockquote — `> summary` followed by `> [!NOTE]` is the documented doc skeleton
+
+  // ── Enforced. Listed explicitly even where `default: true` already covers
+  //    them, so the intent is on the record rather than inherited by accident.
+  "MD001": true, // no skipped heading levels
+  "MD003": { "style": "atx" }, // `#` headings only
+  "MD025": { "front_matter_title": "" }, // exactly one H1 per document; the frontmatter `title` is not counted, since the schema has both
+  "MD040": true, // every fenced code block declares a language
+  "MD041": false // first line need not be a heading — every document starts with frontmatter
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,8 +137,9 @@ frontmatter 다음은 반드시: `# H1`(문서당 하나) → `> 한 줄 요약`
 - 코드펜스는 **언어 태그 필수** (`bash`, `ts`, `js`, `json`, `jsonc`, `yaml`, `text`)
 - 구조화된 사실(파라미터·경로·옵션)은 표로
 - 주의·경고는 GitHub admonition: `> [!NOTE]`, `> [!WARNING]`
-- 본문 언어는 한국어, 기술 용어는 영어 그대로
-- 린트: `npm run lint:md` (markdownlint-cli2, 설정은 루트 `.markdownlint-cli2.jsonc`). globs는 이관된 문서만 게이트 — 레거시 flat 문서는 `ignores`로 유예.
+- **본문 언어는 영어.** 워크스페이스 공통 규칙이며 SSOT는 [skkuverse/CLAUDE.md](https://github.com/spencer0124/skkuverse/blob/main/CLAUDE.md)다. 유일한 예외는 사용자에게 전달되는 제품 카피(`label.ko`, i18n 문자열) — 문서가 아니라 데이터다. 예외 경로는 이 레포의 `.conventions.json`에 선언한다.
+  - 이 줄은 원래 "본문 언어는 한국어"였다. 남아 있는 한국어 문서는 아직 이관 전이며, 손대는 부분부터 영어로 옮긴다.
+- 린트: `npm run lint:md` (markdownlint-cli2). **규칙은 `.markdownlint.jsonc`** — umbrella의 `conventions/markdownlint.jsonc`에서 `conventions.markdownlint` 계약으로 vendoring되고 해시 락으로 고정된다. 직접 수정하지 말고 umbrella를 고쳐 `skkuverse_sync.py pull`을 돌린다. 어떤 경로를 검사할지(globs/ignores)만 루트 `.markdownlint-cli2.jsonc`에 로컬로 둔다.
 
 ### 6. 라이프사이클
 


### PR DESCRIPTION
## Why

This repo carried its own copy of rules that four repos each maintained separately — and one had drifted into **contradicting** the workspace policy:

> `docs/README.md` §5: `본문 언어는 한국어, 기술 용어는 영어 그대로`

while [`skkuverse/CLAUDE.md`](https://github.com/spencer0124/skkuverse/blob/main/CLAUDE.md) mandates English everywhere. Copies of a rule do not stay copies.

The `.markdownlint-cli2.jsonc` here and skkuverse-app's were **byte-identical except for `globs` and `ignores`** — which is exactly where the seam belongs.

## What changed

| | |
|---|---|
| `.markdownlint.jsonc` | **new, vendored** from `skkuverse/conventions/markdownlint.jsonc`, hash-locked by the `conventions.markdownlint` contract |
| `.markdownlint-cli2.jsonc` | now `extends` it and keeps only `globs`/`ignores` — **rules central, globs local** |
| `.conventions.json` | **new** — declares this repo's four Korean-product-copy files |
| `ci.yml` | conventions check, over the umbrella clone it already makes |
| `docs/README.md` §5 | says **English**, and points at the umbrella as SSOT instead of restating the rule |

`.conventions.json` exempts `src/notices/{sources,categories,exclude-reasons}.json` and `src/infra/i18n.ts` — `label.ko` department names and the UI string table. Those are **data shipped to users**, not documentation.

## Two deliberate choices

**`--only frontmatter --only structure`, not the full check.** `language` fails today because `docs/` is still Korean. Turning the whole check off until that finishes would leave the two rules this repo *already satisfies* ungated for however long the translation takes. Add `language` when `docs/` is English.

**The contract stays `planned`.** This lock entry is deliberately **ahead of activation** — `check` reports it as `ahead` and tolerates it:

```
ahead   conventions.markdownlint — locked here, not active in the manifest yet
```

Activating before every consumer has vendored it would break their default branches for the window in between. It flips to `active` once skkuverse-app lands its copy.

## No new dependency

The checker is stdlib-only Python and rides the clone this workflow already performs for `skkuverse_sync.py`. No `setup-python`, no npm package, nothing for `knip` or `depcheck` to see.

## Verification

```console
conventions          OK frontmatter, OK structure
contract integrity   4 ok, 1 ahead
markdownlint         12 files, 0 issues  ← through the vendored rules
tests                411 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)