### PR TITLE
ci: follow the umbrella's exported/ path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Fetch contract tooling
         run: git clone --depth 1 https://github.com/spencer0124/skkuverse "$RUNNER_TEMP/sv"
       - name: Contract integrity
-        run: python3 "$RUNNER_TEMP/sv/tools/skkuverse_sync.py" check --repo server --root .
+        run: python3 "$RUNNER_TEMP/sv/exported/sync_contracts.py" check --repo server --root .
       - run: npm test
         env:
           NAVER_MAP_STYLE_ID: ${{ secrets.NAVER_MAP_STYLE_ID }}

--- a/.github/workflows/contracts-sync.yml
+++ b/.github/workflows/contracts-sync.yml
@@ -45,7 +45,7 @@ jobs:
         # explicitly gets `bash --noprofile --norc -eo pipefail {0}`.
         shell: bash
         run: |
-          python3 "$RUNNER_TEMP/sv/tools/skkuverse_sync.py" pull --repo server --root . \
+          python3 "$RUNNER_TEMP/sv/exported/sync_contracts.py" pull --repo server --root . \
             | tee "$RUNNER_TEMP/pull.txt"
 
       # No drift means `pull` wrote nothing at all — it rewrites a lock only

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Fetch contract tooling
         run: git clone --depth 1 https://github.com/spencer0124/skkuverse "$RUNNER_TEMP/sv"
       - name: Contract integrity
-        run: python3 "$RUNNER_TEMP/sv/tools/skkuverse_sync.py" check --repo server --root .
+        run: python3 "$RUNNER_TEMP/sv/exported/sync_contracts.py" check --repo server --root .
       - run: npm test
         env:
           NAVER_MAP_STYLE_ID: ${{ secrets.NAVER_MAP_STYLE_ID }}

--- a/src/notices/notices.topics.ts
+++ b/src/notices/notices.topics.ts
@@ -21,7 +21,7 @@ import type { CategoryConfig } from "./types";
 // intermediate state green while still catching the reverse, which is the
 // dangerous one. CI enforces it against the value recorded in
 // .contracts.lock.json — do not hand-edit that file; run
-// `skkuverse_sync.py pull --repo server`.
+// `sync_contracts.py pull --repo server`.
 //
 // 30 is Firestore's real `array-contains-any` limit. The previous 10 was a
 // self-imposed "MVP conservative limit" (see the CF's types.ts), and it became


### PR DESCRIPTION
## Why

The umbrella split its tooling into `exported/` and `internal/` ([spencer0124/skkuverse#10](https://github.com/spencer0124/skkuverse/pull/10)). The script this repo runs moved:

```
tools/skkuverse_sync.py  →  exported/sync_contracts.py
```

Same subcommands, same flags, same behaviour. Only the path changes.

## Timing

This repo clones the umbrella's `main` **unpinned**, so there is no version to pin against. Merge this immediately after the umbrella PR — until then the clone-and-run step fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfaUHn2xb2rEkeVzX3WXLt