### PR TITLE
ci: follow the umbrella's exported/ path (dev)

### DIFF
--- a/.conventions.json
+++ b/.conventions.json
@@ -1,5 +1,5 @@
 {
-  "_note": "Exceptions to the shared SKKUverse conventions, declared by this repo. Checked by tools/conventions_lint.py in spencer0124/skkuverse. Keep exceptions here rather than centrally, so whoever needs one declares it in the same commit as the code that needs it.",
+  "_note": "Exceptions to the shared SKKUverse conventions, declared by this repo. Checked by exported/lint_conventions.py in spencer0124/skkuverse. Keep exceptions here rather than centrally, so whoever needs one declares it in the same commit as the code that needs it.",
 
   "_productCopy": "Korean that IS the product rather than documentation. src/notices/*.json carry label.ko for department and category names; infra/i18n.ts is the server-generated UI string table. Both are data shipped to users.",
   "productCopy": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Fetch contract tooling
         run: git clone --depth 1 https://github.com/spencer0124/skkuverse "$RUNNER_TEMP/sv"
       - name: Contract integrity
-        run: python3 "$RUNNER_TEMP/sv/tools/skkuverse_sync.py" check --repo server --root .
+        run: python3 "$RUNNER_TEMP/sv/exported/sync_contracts.py" check --repo server --root .
       # Shared conventions, defined once in the umbrella. Same clone, so this
       # adds no dependency and no install step.
       #
@@ -48,7 +48,7 @@ jobs:
       # when docs/ is English.
       - name: Conventions
         run: |
-          python3 "$RUNNER_TEMP/sv/tools/conventions_lint.py" --root . \
+          python3 "$RUNNER_TEMP/sv/exported/lint_conventions.py" --root . \
             --only frontmatter --only structure
       - run: npm test
         env:

--- a/.github/workflows/contracts-sync.yml
+++ b/.github/workflows/contracts-sync.yml
@@ -45,7 +45,7 @@ jobs:
         # explicitly gets `bash --noprofile --norc -eo pipefail {0}`.
         shell: bash
         run: |
-          python3 "$RUNNER_TEMP/sv/tools/skkuverse_sync.py" pull --repo server --root . \
+          python3 "$RUNNER_TEMP/sv/exported/sync_contracts.py" pull --repo server --root . \
             | tee "$RUNNER_TEMP/pull.txt"
 
       # No drift means `pull` wrote nothing at all — it rewrites a lock only

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Fetch contract tooling
         run: git clone --depth 1 https://github.com/spencer0124/skkuverse "$RUNNER_TEMP/sv"
       - name: Contract integrity
-        run: python3 "$RUNNER_TEMP/sv/tools/skkuverse_sync.py" check --repo server --root .
+        run: python3 "$RUNNER_TEMP/sv/exported/sync_contracts.py" check --repo server --root .
       - run: npm test
         env:
           NAVER_MAP_STYLE_ID: ${{ secrets.NAVER_MAP_STYLE_ID }}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -4,7 +4,7 @@
     // Rules come from .markdownlint.jsonc, vendored from the umbrella by the
     // `conventions.markdownlint` contract and hash-locked in
     // .contracts.lock.json. Do not edit that file — edit
-    // skkuverse/conventions/markdownlint.jsonc and run `skkuverse_sync.py pull`.
+    // skkuverse/conventions/markdownlint.jsonc and run `sync_contracts.py pull`.
     //
     // Rules central, globs local: which paths this repo lints is genuinely
     // repo-specific and stays below.

--- a/docs/README.md
+++ b/docs/README.md
@@ -139,7 +139,7 @@ frontmatter 다음은 반드시: `# H1`(문서당 하나) → `> 한 줄 요약`
 - 주의·경고는 GitHub admonition: `> [!NOTE]`, `> [!WARNING]`
 - **본문 언어는 영어.** 워크스페이스 공통 규칙이며 SSOT는 [skkuverse/CLAUDE.md](https://github.com/spencer0124/skkuverse/blob/main/CLAUDE.md)다. 유일한 예외는 사용자에게 전달되는 제품 카피(`label.ko`, i18n 문자열) — 문서가 아니라 데이터다. 예외 경로는 이 레포의 `.conventions.json`에 선언한다.
   - 이 줄은 원래 "본문 언어는 한국어"였다. 남아 있는 한국어 문서는 아직 이관 전이며, 손대는 부분부터 영어로 옮긴다.
-- 린트: `npm run lint:md` (markdownlint-cli2). **규칙은 `.markdownlint.jsonc`** — umbrella의 `conventions/markdownlint.jsonc`에서 `conventions.markdownlint` 계약으로 vendoring되고 해시 락으로 고정된다. 직접 수정하지 말고 umbrella를 고쳐 `skkuverse_sync.py pull`을 돌린다. 어떤 경로를 검사할지(globs/ignores)만 루트 `.markdownlint-cli2.jsonc`에 로컬로 둔다.
+- 린트: `npm run lint:md` (markdownlint-cli2). **규칙은 `.markdownlint.jsonc`** — umbrella의 `conventions/markdownlint.jsonc`에서 `conventions.markdownlint` 계약으로 vendoring되고 해시 락으로 고정된다. 직접 수정하지 말고 umbrella를 고쳐 `sync_contracts.py pull`을 돌린다. 어떤 경로를 검사할지(globs/ignores)만 루트 `.markdownlint-cli2.jsonc`에 로컬로 둔다.
 
 ### 6. 라이프사이클
 

--- a/src/notices/notices.topics.ts
+++ b/src/notices/notices.topics.ts
@@ -21,7 +21,7 @@ import type { CategoryConfig } from "./types";
 // intermediate state green while still catching the reverse, which is the
 // dangerous one. CI enforces it against the value recorded in
 // .contracts.lock.json — do not hand-edit that file; run
-// `skkuverse_sync.py pull --repo server`.
+// `sync_contracts.py pull --repo server`.
 //
 // 30 is Firestore's real `array-contains-any` limit. The previous 10 was a
 // self-imposed "MVP conservative limit" (see the CF's types.ts), and it became


### PR DESCRIPTION
## Why

Same change as #89, applied to `dev`, which carries one reference `main` does not yet have:

```
tools/skkuverse_sync.py    →  exported/sync_contracts.py
tools/conventions_lint.py  →  exported/lint_conventions.py   ← dev only
```

`dev` is 2 commits ahead of `main` (the shared-conventions adoption), so fixing `main` alone would leave `dev`'s CI broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfaUHn2xb2rEkeVzX3WXLt